### PR TITLE
Mise à jour des lignes de code dépréciées dans le futur + makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: console migrate migrations server dependencies
+.PHONY: console migrate migrations server
 
 # DEVELOPMENT
 # ~~~~~~~~~~~
@@ -18,15 +18,12 @@ migrations:
 server:
 	python manage.py runserver
 
-dependencies:
-	poetry lock; poetry run poe export; poetry run poe export_dev
-
 # QUALITY ASSURANCE
 # ~~~~~~~~~~~~~~~~~
 # The following rules can be used to check code quality, import sorting, etc.
 # --------------------------------------------------------------------------------------------------
 
-.PHONY: quality fix pylint tests
+.PHONY: quality fix pylint test
 quality:
 	black --check lacommunaute
 	isort --check --profile black lacommunaute
@@ -41,7 +38,7 @@ fix:
 pylint:
 	pylint lacommunaute
 
-tests:
+test:
 	pytest --numprocesses=logical --create-db
 
 # Docker shell.

--- a/lacommunaute/forum/factories.py
+++ b/lacommunaute/forum/factories.py
@@ -18,6 +18,9 @@ class ForumFactory(BaseForumFactory):
     description = factory.Faker("sentence", nb_words=100)
     short_description = factory.Faker("sentence", nb_words=10)
 
+    class Meta:
+        skip_postgeneration_save = True
+
     @factory.post_generation
     def with_public_perms(self, create, extracted, **kwargs):
         if not create or not extracted:

--- a/lacommunaute/forum_conversation/factories.py
+++ b/lacommunaute/forum_conversation/factories.py
@@ -13,6 +13,9 @@ class PostFactory(BasePostFactory):
     content = factory.Faker("sentence", nb_words=40)
     poster = factory.SubFactory(UserFactory)
 
+    class Meta:
+        skip_postgeneration_save = True
+
     @factory.post_generation
     def upvoted_by(self, create, extracted, **kwargs):
         if not create or not extracted:
@@ -37,6 +40,9 @@ class TopicFactory(BaseTopicFactory):
     poster = factory.SubFactory(UserFactory)
     subject = factory.Faker("sentence", nb_words=5)
     type = Topic.TOPIC_POST
+
+    class Meta:
+        skip_postgeneration_save = True
 
     class Params:
         with_post = factory.Trait(

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -598,7 +598,7 @@ class NewsFeedTopicListViewTest(TestCase):
 
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertQuerysetEqual(response.context_data["topics"], [topic for topic in news_topics[::-1]])
+        self.assertQuerySetEqual(response.context_data["topics"], [topic for topic in news_topics[::-1]])
 
     def test_context_data(self):
         response = self.client.get(self.url)

--- a/lacommunaute/metabase/tests/test_extract_tables_command.py
+++ b/lacommunaute/metabase/tests/test_extract_tables_command.py
@@ -123,7 +123,7 @@ def test_extract_upvoted_post_tables_command():
     assert upvoted_posttable.post_upvotes_count == 1
 
 
-@override_settings(DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage")
+@override_settings(STORAGES={"default": {"BACKEND": "django.core.files.storage.FileSystemStorage"}})
 @pytest.mark.django_db
 def test_extract_post_with_attachments_tables_command():
     topic = TopicFactory(with_post=True)

--- a/lacommunaute/utils/tests.py
+++ b/lacommunaute/utils/tests.py
@@ -27,6 +27,8 @@ faker = Faker()
 PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
 assign_perm = get_class("forum_permission.shortcuts", "assign_perm")
 
+override_storage = {"default": {"BACKEND": "django.core.files.storage.FileSystemStorage"}}
+
 
 class AttachmentsTemplateTagTests(TestCase):
     @classmethod
@@ -34,7 +36,7 @@ class AttachmentsTemplateTagTests(TestCase):
         topic = TopicFactory(with_post=True)
         cls.post = topic.posts.first()
 
-    @override_settings(DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage")
+    @override_settings(STORAGES=override_storage)
     def test_is_an_image(self):
         for filename in ["test.png", "test.jpg", "test.JPG", "test.jpeg", "test.JPEG"]:
             with self.subTest(filename=filename):
@@ -50,7 +52,7 @@ class AttachmentsTemplateTagTests(TestCase):
                 )
                 self.assertEqual(out, "True")
 
-    @override_settings(DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage")
+    @override_settings(STORAGES=override_storage)
     def test_is_not_an_image(self):
         for filename in ["test.csv", "test.xlsx", "test.pdf", "test.html"]:
             with self.subTest(filename=filename):
@@ -66,7 +68,7 @@ class AttachmentsTemplateTagTests(TestCase):
                 )
                 self.assertEqual(out, "False")
 
-    @override_settings(DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage")
+    @override_settings(STORAGES=override_storage)
     def test_is_available(self):
         f = SimpleUploadedFile("test.png", force_bytes("file_content"))
         attachment = AttachmentFactory(post=self.post, file=f)
@@ -80,7 +82,7 @@ class AttachmentsTemplateTagTests(TestCase):
         )
         self.assertEqual(out, "True")
 
-    @override_settings(DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage")
+    @override_settings(STORAGES=override_storage)
     def test_is_not_available(self):
         f = SimpleUploadedFile("test.png", force_bytes("file_content"))
         attachment = AttachmentFactory(post=self.post, file=f)


### PR DESCRIPTION
## Description

🦺 Mise à jour du `Makefile`
🦺 Mise à jour des tests en regard des `deprecation warning` 
    * factory boy : `Factory._after_postgeneration will stop saving the instance after postgeneration hooks in the next major release`
    * file storage : `django.core.files.storage.get_storage_class is deprecated in favor of using django.core.files.storage.storages`
    * assertion : `assertQuerySetEqual`

## Type de changement

🚧 technique
