### PR TITLE
[HOME] afficher les dates/heures sur la page d'accueil (fix)

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/poster_light.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster_light.html
@@ -1,5 +1,5 @@
 {% load date_filters %}
 <small class="text-muted">
     {% if poster %}par : {{ poster }},{% endif %}
-    {{ created|relativetimesince_fr }}
+    {{ dated|relativetimesince_fr }}
 </small>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -96,7 +96,7 @@
                                            data-matomo-category="engagement"
                                            data-matomo-action="view"
                                            data-matomo-option="topic">{{ topic.subject }}</a>
-                                        {% include "forum_conversation/partials/poster_light.html" with poster=topic.first_post.poster_display_name created=topic.created only %}
+                                        {% include "forum_conversation/partials/poster_light.html" with poster=topic.first_post.poster_display_name dated=topic.created only %}
                                     </li>
                                 {% endfor %}
                             </ul>
@@ -121,7 +121,7 @@
                                         <a href="{% url 'forum_extension:forum' forum.slug forum.pk %}" class="matomo-event btn-link stretched-link" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">
                                             [{{ forum.parent.name }}] {{ forum.name }}
                                         </a>
-                                        {% include "forum_conversation/partials/poster_light.html" with poster=None created=forum.created only %}
+                                        {% include "forum_conversation/partials/poster_light.html" with poster=None dated=forum.updated only %}
                                     </li>
                                 {% endfor %}
                             </ul>
@@ -148,7 +148,7 @@
                                            data-matomo-category="engagement"
                                            data-matomo-action="view"
                                            data-matomo-option="news">{{ topic.subject }}</a>
-                                        {% include "forum_conversation/partials/poster_light.html" with poster=None created=topic.created only %}
+                                        {% include "forum_conversation/partials/poster_light.html" with poster=None dated=topic.created only %}
                                     </li>
                                 {% endfor %}
                             </ul>


### PR DESCRIPTION
## Description
#481 

Afficher la date de mise à jour pour les fiches techniques (au lieu de la date de creation)

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

