### PR TITLE
Éviter d’exposer la base de données au public pendant le développement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./docker/postgres/psql_init.sh:/docker-entrypoint-initdb.d/postgres-init.sh
     restart: always
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
 
   django:
     container_name: commu_django
@@ -30,15 +30,15 @@ services:
       - .:/app
     restart: always
     ports:
-      - "${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
-      - "${DJANGO_DEBUGPY_PORT:-5678}:5678"
+      - "127.0.0.1:${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
+      - "127.0.0.1:${DJANGO_DEBUGPY_PORT:-5678}:5678"
 
   mailhog:
     image: mailhog/mailhog:latest
     restart: always
     ports:
-      - 1025:1025
-      - 8025:8025
+      - 127.0.0.1:1025:1025
+      - 127.0.0.1:8025:8025
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Éviter d’exposer la base de données au public pendant le développement

## Description

La machine de dev était configurée pour écouter les demandes sur le réseau. Lors du développement dans un environnement partagé (café, train, coworking), d’autres personnes du réseau peuvent se connecter à la base de données (en l’absence de parefeu ou s’il est mal configuré), et éventuellement récupérer son contenu, s’ils devinent le mot de passe utilisé dans l’environnement de développement.

## Type de changement

🚧 technique
