### PR TITLE
Permettre de filtrer les sujets avec des tags en majuscule

### DIFF
--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -115,7 +115,7 @@ class TopicListView(ListView):
 
     def get_tags(self):
         if not hasattr(self, "tags"):
-            self.tags = self.request.GET.get("tags", None)
+            self.tags = self.request.GET.get("tags", "").lower()
         return self.tags
 
     def get_queryset(self):


### PR DESCRIPTION
## Description

Amélioration du filtrage par tag, en ignorant les majuscules.
Correction d’un test qui échouait de manière intermittente.

## Type de changement

🪲 Correction de bug
🚧 technique
