### PR TITLE
Retirer le setting USE_L10N

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -191,7 +191,6 @@ AUTHENTICATION_BACKENDS = (
 
 LANGUAGE_CODE = "fr-FR"
 USE_I18N = True
-USE_L10N = True
 LOCALE_PATHS = (os.path.join(ROOT_DIR, "locale"),)
 
 TIME_ZONE = "Europe/Paris"


### PR DESCRIPTION
## Description

`True` est la valeur par défault, et le setting sera supprimé dans Django 5.0.

## Type de changement

🚧 technique
