### PR TITLE
[HOMEPAGE] AB test fréquentation de la page documentation

### DIFF
--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -48,12 +48,16 @@
                             <span class="ms-2">Progressez grâce à des ressources exclusives</span>
                         </li>
                     </ul>
-                    {% include "partials/ask_a_question.html" %}
                 </div>
                 <div class="s-hero-title-01__col col-12 d-none d-lg-inline-flex col-md-4">
                     <div>
                         <img src="{% static 'images/hp-illustration-01.svg' %}" class="img-fluid w-lg-75" loading="lazy" alt="">
                     </div>
+                </div>
+            </div>
+            <div class="s-hero-title-01__row row align-items-center">
+                <div class="s-hero-title-01__col s-hero-title-01__col--title col-12 mt-3 mt-lg-5">
+                    {% include "partials/ask_a_question.html" %}
                 </div>
             </div>
         </div>
@@ -202,4 +206,39 @@
             setTimeout(displayTallyPopup, delayBeforeShowingPopupInSeconds * 1000);
         };
     </script>
+    <!-- Matomo A/B Test -->
+    <script type="text/javascript">
+        var _paq = _paq || [];
+        _paq.push(['AbTesting::create', {
+            name: 'first_dummy_test', // you can also use '2' (ID of the experiment) to hide the name
+            percentage: 100,
+            includedTargets: [{
+                "attribute": "url",
+                "inverted": "0",
+                "type": "equals_simple",
+                "value": "https:\/\/communaute.inclusion.beta.gouv.fr\/"
+            }],
+            excludedTargets: [],
+            variations: [{
+                name: 'original',
+                activate: function(event) {
+                    // usually nothing needs to be done here
+                }
+            }, {
+                name: 'bouton_plein', // you can also use '2' (ID of the variation) to hide the name
+                activate: function(event) {
+                    event.redirect('https://communaute.inclusion.beta.gouv.fr/?btn=pl');
+                }
+            }, {
+                name: 'bouton_outlined', // you can also use '3' (ID of the variation) to hide the name
+                activate: function(event) {
+                    event.redirect('https://communaute.inclusion.beta.gouv.fr/?btn=outl');
+                }
+            }],
+            trigger: function() {
+                return true; // here you can further customize which of your visitors will participate in this experiment
+            }
+        }]);
+    </script>
+    <!-- Matomo A/B Test -->
 {% endblock %}

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -23,5 +23,20 @@
                 <span>{% trans "Search forums" %}</span>
             </a>
         </div>
+        {% comment %}AB Test - variation bouton documentation{% endcomment %}
+        {% if request.GET.btn %}
+            <div class="col-12 col-md-auto py-1 py-md-0 px-md-0 text-center">ou</div>
+            <div class="col-12 col-md-auto">
+                <a href="{% url 'forum_extension:documentation' %}"
+                   class="btn {% if request.GET.btn == 'pl' %}btn-primary{% else %}btn-outline-primary{% endif %} btn-ico btn-block matomo-event"
+                   data-matomo-category="engagement"
+                   data-matomo-action="view"
+                   data-matomo-option="documentation">
+                    <span>Consulter la documentation</span>
+                </a>
+            </div>
+            {% comment %}END AB Test - variation bouton documentation{% endcomment %}
+            <div id="bouton_outlined" class="d-none">yyy</div>
+        {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
## Description

🎸 AB test - Fréquentation de la page documentation selon l'installation d'un bouton spécifique sur la homepage.

Version Originale

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/17afaf4d-f18f-4f39-89bf-4cef2ce7c742)

Variation Ajout d'un bouton plein

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/2334cc06-a52b-48ec-8ee2-204e15d898e9)


Variation Ajout d'un bouton outlined

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/abd9b3c3-8159-479d-a4e7-5bfa98e9d7ac)



## Type de changement

🎨 UI

### Points d'attention

🦺 Ajout d'un script matomo dans `home.html`
🦺 La bascule d'UI est gérée via le param `btn` dans l'url


## Definition du test dans Matomo (FYI)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/d5466969-149f-4372-8a68-3f74223cdf9f)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/00357729-aeb6-4142-8eab-cf934f00f716)


![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/1052350c-9780-4170-bc47-f92b5fd2da44)


![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/01212162-9004-4213-9793-202694aa9115)


![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/fbe5de69-51d0-44b8-8466-2c6f17a48604)


![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/7ad0714d-35d3-4cbf-9152-ce3fdb4e32b1)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/6b30b3f7-1797-43b7-a91c-264fc4ae824e)

