### PR TITLE
Permettre d’activer le suivi de perfs Sentry

### DIFF
--- a/config/settings/_sentry.py
+++ b/config/settings/_sentry.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -33,13 +34,18 @@ sentry_logging = LoggingIntegration(
 
 
 def sentry_init(dsn):
+    try:
+        traces_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", ""))
+    except ValueError:
+        traces_sample_rate = 0
+
     sentry_sdk.init(
         dsn=dsn,
         integrations=[sentry_logging, DjangoIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=0,
+        traces_sample_rate=traces_sample_rate,
         # Associate users (ID+email+username+IP) to errors.
         # https://docs.sentry.io/platforms/python/django/
         send_default_pii=True,


### PR DESCRIPTION
## Description

🎸 Activer https://docs.sentry.io/product/performance/.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).


- [x] TODO(@vincentporte): Définir `SENTRY_TRACES_SAMPLE_RATE=0.01` (ou autre valeur) dans CleverCloud, en gardant à l’esprit qu’on paye en fonction du nombre de transactions mesurées.