### PR TITLE
Préférer les styles itou à machina.board_theme

### DIFF
--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -51,9 +51,9 @@
         {% block extra_head %}{% endblock %}
         {% block css %}
             <link rel="shortcut icon" href="{% static_theme_images "favicon.ico" %}" type="image/ico">
-            {% import_static_CSS_theme_inclusion %}
             <link rel="stylesheet" href="{% static 'machina/build/css/machina.board_theme.vendor.min.css' %}">
             <link rel="stylesheet" href="{% static 'machina/build/css/machina.board_theme.min.css' %}">
+            {% import_static_CSS_theme_inclusion %}
         {% endblock %}
         {% compress css %}
             <link rel="stylesheet" href="{% static 'stylesheets/itou_communaute.scss' %}" type="text/x-scss">


### PR DESCRIPTION
## Description

En cas de conflits, les thèmes définis par l’équipe devraient avoir la précédence.

## Type de changement

🚧 technique

Refs #526 