### PR TITLE
Retirer noqa: T027 des options de partage

### DIFF
--- a/lacommunaute/templates/partials/social_share_buttons.html
+++ b/lacommunaute/templates/partials/social_share_buttons.html
@@ -7,6 +7,6 @@
     {% post_to_facebook instance '<i class="ri-facebook-fill ri-lg"></i> Partager sur Facebook' %}
     {% post_to_whatsapp instance '<i class="ri-whatsapp-line ri-lg"></i> Partager sur Whatsapp' %}
     {% post_to_twitter text instance '<i class="ri-twitter-line ri-lg"></i> Partager sur Twitter' %}
-    {% send_email text "Ce lien peut t'intéresser :" instance '<i class="ri-mail-line ri-lg"></i> Partager par email' %} # noqa T027
+    {% send_email text "Ce lien peut t'intéresser :" instance '<i class="ri-mail-line ri-lg"></i> Partager par email' %}
     {% post_to_linkedin instance %}
 </div>


### PR DESCRIPTION
## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Captures d'écran.

#### Avant

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/2758243/b87d8fc4-39a2-4d55-a96a-a732c95273ad)

#### Après

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/2758243/c8a79ae6-0f38-491b-b5ad-d94e8fff80f6)

