### PR TITLE
Reactivation de la bannière les 2 font la paires

### DIFF
--- a/lacommunaute/templates/partials/promotion_banner.html
+++ b/lacommunaute/templates/partials/promotion_banner.html
@@ -1,4 +1,4 @@
-<div class="alert alert-communaute alert-dismissible fade show" role="status">
+<div class="alert alert-info alert-dismissible fade show" role="status">
     <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
     <div class="row">
         <div class="col-auto pe-0">
@@ -6,20 +6,12 @@
         </div>
         <div class="col">
             <p class="mb-2">
-                <strong>L'inclusion aujourd'hui, les défis de demain</strong>
+                <strong>Lancez la discussion !</strong>
             </p>
-            <p class="mb-0">
-                Le jeudi 01 février 2024, les professionnels de l'inclusion ont rendez-vous de 09h à 17h
-                <br class="d-none d-lg-inline">
-                pour un événement en ligne incontournable.
-            </p>
+            <p class="mb-0">🤝 Partagez vos experiences et trouvez un binôme en insertion professionnelle.</p>
         </div>
         <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-            <a href="https://swll.to/lzyt8Y"
-               class="btn btn-sm btn-primary has-external-link matomo-event"
-               data-matomo-category="promotion-partenaires"
-               data-matomo-action="clic"
-               data-matomo-option="inclusion-demain">Je m'inscris</a>
+            <a href="https://tally.so/r/mOXyWK" class="btn btn-sm btn-primary matomo-event" data-matomo-category="promotion-partenaires" data-matomo-action="clic" data-matomo-option="binome">Trouver un binôme d'entraide</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

🎸 Remplacer la banniere d'inscription  à inclusion-demain par la bannière "les 2 font la paire"

## Type de changement

🎨 UI

### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/ecc9c0b6-fd85-422b-932c-545ee6094e56)