### PR TITLE
[STATS] impact sans limite de durée

### DIFF
--- a/lacommunaute/pages/tests/tests.py
+++ b/lacommunaute/pages/tests/tests.py
@@ -101,7 +101,6 @@ class StatistiquesPageTest(TestCase):
         # undesired data
         StatFactory(name="nb_uniq_visitors_returning", period=Period.DAY, date=today)
         StatFactory(name=faker.word(), period=Period.MONTH, date=today)
-        StatFactory(name="nb_uniq_visitors_returning", period=Period.MONTH, date=today - timezone.timedelta(days=125))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["impact"], empty_res)

--- a/lacommunaute/pages/views.py
+++ b/lacommunaute/pages/views.py
@@ -67,9 +67,8 @@ class StatistiquesPageView(TemplateView):
 
     def get_monthly_visitors(self):
         indicator_names = ["nb_uniq_visitors_returning"]
-        after_date = timezone.now() - timezone.timedelta(days=124)  # 4 months
         datas = (
-            Stat.objects.filter(period="month", name__in=indicator_names, date__gte=after_date)
+            Stat.objects.filter(period="month", name__in=indicator_names)
             .values("name", "value")
             .annotate(date=Cast("date", CharField()))
         )


### PR DESCRIPTION
## Description

🎸 Supprimer la limite de 3 mois sur l'extraction des stats d'impact mensuelles

## Type de changement

🎨 UI

