### PR TITLE
[HOMEPAGE] fin AB Test, ajout bouton outlined vers la documentation

### DIFF
--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -206,42 +206,4 @@
             setTimeout(displayTallyPopup, delayBeforeShowingPopupInSeconds * 1000);
         };
     </script>
-    <!-- Matomo A/B Test -->
-    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
-        var _paq = _paq || [];
-        _paq.push(['AbTesting::create', {
-            name: 'Documentation_sur_la_homepage', // you can also use '4' (ID of the experiment) to hide the name
-            percentage: 100,
-            includedTargets: [{
-                "attribute": "url",
-                "inverted": "0",
-                "type": "any",
-                "value": ""
-            }],
-            excludedTargets: [],
-            variations: [{
-                name: 'original',
-                activate: function(event) {
-                    // usually nothing needs to be done here
-                }
-            }, {
-                name: 'btn_plein', // you can also use '6' (ID of the variation) to hide the name
-                activate: function(event) {
-                    $("#btn_plein").removeClass("d-none")
-                    $("#btn_sep").removeClass("d-none")
-
-                }
-            }, {
-                name: 'btn_outlined', // you can also use '7' (ID of the variation) to hide the name
-                activate: function(event) {
-                    $("#btn_outlined").removeClass("d-none")
-                    $("#btn_sep").removeClass("d-none")
-                }
-            }],
-            trigger: function() {
-                return true; // here you can further customize which of your visitors will participate in this experiment
-            }
-        }]);
-    </script>
-    <!-- Matomo A/B Test -->
 {% endblock %}

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -19,14 +19,8 @@
                 <span>{% trans "Search forums" %}</span>
             </a>
         </div>
-        {% comment %}AB Test - variation bouton documentation{% endcomment %}
-        <div id="btn_sep" class="col-12 col-md-auto py-1 py-md-0 px-md-0 text-center d-none">ou</div>
-        <div id="btn_plein" class="col-12 col-md-auto d-none">
-            <a href="{% url 'forum_extension:documentation' %}" class="btn btn-primary btn-ico btn-block matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation">
-                <span>Consulter la documentation</span>
-            </a>
-        </div>
-        <div id="btn_outlined" class="col-12 col-md-auto d-none">
+        <div class="col-12 col-md-auto py-1 py-md-0 px-md-0 text-center">ou</div>
+        <div class="col-12 col-md-auto">
             <a href="{% url 'forum_extension:documentation' %}"
                class="btn btn-outline-primary btn-ico btn-block matomo-event"
                data-matomo-category="engagement"
@@ -35,6 +29,5 @@
                 <span>Consulter la documentation</span>
             </a>
         </div>
-        {% comment %}END AB Test - variation bouton documentation{% endcomment %}
     </div>
 {% endif %}


### PR DESCRIPTION
## Description

🎸 L'AB Test a revelé que l'ajout d'un bouton vers la documentation augmente significativement le taux de conversion de la page. La version 'outlined' obtient des résultats légèrement meilleurs que le bouton plein. Le bouton `outlined` est mis en place.

## Type de changement

🎨 UI

### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/c6ee02e0-2cc9-4b13-8444-a842d4ee0c13)