### PR TITLE
[MODERATION] activation de la moderation queue

### DIFF
--- a/lacommunaute/templates/forum_conversation/topic_create.html
+++ b/lacommunaute/templates/forum_conversation/topic_create.html
@@ -6,7 +6,11 @@
 {% endblock sub_title %}
 {% block content %}
     <div class="row">
-        <div class="col-12 mb-3 mb-lg-5">{% include "partials/banner.html" %}</div>
+        <div class="col-12 mb-3 mb-lg-5">
+            {% if not user.is_authenticated %}
+                {% include 'partials/anonymous_banner.html' %}
+            {% endif %}
+        </div>
         <div class="col-12">
             <h1>{{ forum.name }}</h1>
         </div>

--- a/lacommunaute/templates/forum_moderation/moderation_queue/list.html
+++ b/lacommunaute/templates/forum_moderation/moderation_queue/list.html
@@ -1,0 +1,92 @@
+{% extends 'board_base.html' %}
+{% load i18n %}
+{% load forum_member_tags %}
+{% block sub_title %}
+    {% trans "Moderation queue" %}
+{% endblock sub_title %}
+{% block content %}
+    <div class="row">
+        <div class="col-12">
+            <h1>{% trans "Moderation queue" %}</h1>
+        </div>
+    </div>
+    <div class="mb-3 row">
+        <div class="col-6 col-md-4 forum-actions-block">
+            {% if paginator.count > 0 %}
+                <p class="mt-1 mb-0 text-muted">
+                    {% blocktrans with paginator.count as topic_length %}{{ topic_length }} posts found{% endblocktrans %}
+                </p>
+            {% endif %}
+        </div>
+        <div class="col-12 col-md-8 pagination-block">
+            {% with "pagination-sm justify-content-end" as pagination_size %}
+                {% include "partials/pagination.html" %}
+            {% endwith %}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-12">
+            <div class="card postmoderationlist">
+                <div class="card-header">
+                    <div class="row panel-row">
+                        <div class="col-12 col-md-8 post-name-col">
+                            <h3 class="m-0 card-title h5">{% trans "Moderation queue" %}</h3>
+                        </div>
+                        <div class="col-md-2 d-none d-md-block moderation-col">{% trans "Topic" %}</div>
+                        <div class="col-md-2 d-none d-md-block moderation-col">{% trans "Forum" %}</div>
+                    </div>
+                </div>
+                <div class="p-0 card-body">
+                    {% for post in posts %}
+                        <div class="m-0 row">
+                            <div class="col-12 col-md-8 post-name">
+                                <table class="post-data-table">
+                                    <tr>
+                                        <td class="post-name">
+                                            <a href="{% url 'forum_moderation:queued_post' post.pk %}" class="post-name-link">{{ post.subject }}</a>
+                                            <div>
+                                                <div class="post-created">
+                                                    {% if post.poster %}
+                                                        {% url 'member:profile' post.poster_id as poster_url %}
+                                                        {% blocktrans trimmed with poster_url=poster_url username=post.poster|forum_member_display_name creation_date=post.created %}
+                                                            By: <a href="{{ poster_url }}">{{ username }}</a> on {{ creation_date }}
+                                                        {% endblocktrans %}
+                                                    {% else %}
+                                                        {% blocktrans trimmed with poster_username=post.username creation_date=post.created %}
+                                                            By: {{ poster_username }} on {{ creation_date }}
+                                                        {% endblocktrans %}
+                                                    {% endif %}
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                            <div class="col-md-2 d-none d-md-block topic-name">
+                                {% if post.is_topic_head %}
+                                    <span class="badge badge-secondary">{% trans "New topic" %}</span>
+                                {% else %}
+                                    <a href="{% url 'forum_conversation:topic' forum_slug=post.topic.forum.slug forum_pk=post.topic.forum.pk slug=post.topic.slug pk=post.topic.pk %}" class="post-name-link">{{ post.topic.subject }}</a>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-2 d-none d-md-block forum-name">
+                                <a href="{% url 'forum_extension:forum' slug=post.topic.forum.slug pk=post.topic.forum.pk %}" class="post-name-link">{{ post.topic.forum.name }}</a>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="row m-0 px-3 py-2">
+                            <div class="p-0 col-12">{% trans "No posts awaiting approval." %}</div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-12 pagination-block">
+            {% with "pagination-sm justify-content-end" as pagination_size %}
+                {% include "partials/pagination.html" %}
+            {% endwith %}
+        </div>
+    </div>
+{% endblock content %}

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -18,7 +18,13 @@
     <section>
         <div class="s-section__container container">
             <div class="s-section__row row mt-3 mt-md-5">
-                <div class="s-section__col col-12">{% include 'partials/promotion_banner.html' %}</div>
+                <div class="s-section__col col-12">
+                    {% if user.is_authenticated %}
+                        {% include 'partials/promotion_banner.html' %}
+                    {% else %}
+                        {% include 'partials/anonymous_banner.html' %}
+                    {% endif %}
+                </div>
             </div>
         </div>
     </section>

--- a/lacommunaute/templates/partials/anonymous_banner.html
+++ b/lacommunaute/templates/partials/anonymous_banner.html
@@ -1,0 +1,14 @@
+<div class="alert alert-warning alert-dismissible fade show" role="status">
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+    <div class="row">
+        <div class="col-auto pe-0">
+            <i class="ri-alarm-warning-line ri-xl text-warning"></i>
+        </div>
+        <div class="col">
+            <p class="mb-2">
+                Pour que vos questions et réponses apparaissent plus rapidement dans l'espace d'échanges, nous vous recommandons de vous connecter avec votre compte Inclusion Connect.
+                <strong><a href="{% url 'inclusion_connect:authorize' %}" rel="nofollow">Je me connecte !</a></strong>
+            </p>
+        </div>
+    </div>
+</div>

--- a/lacommunaute/templates/partials/header_nav_primary_items.html
+++ b/lacommunaute/templates/partials/header_nav_primary_items.html
@@ -55,6 +55,12 @@
                             <div class="dropdown-divider"></div>
                         </li>
                         <li>
+                            <a class="dropdown-item text-primary" href="{% url 'forum_moderation:queue' %}"><i class="ri-alarm-warning-line ri-xl text-warning"></i>Moderation Queue</a>
+                        </li>
+                        <li>
+                            <div class="dropdown-divider"></div>
+                        </li>
+                        <li>
                             <a class="dropdown-item text-primary" href="{% url 'admin:forum_forum_add' %}">Nouvelle thématique</a>
                         </li>
                         <li>


### PR DESCRIPTION
## Description

🎸 ajout d'un lien dans le menu superuser pour accéder à la liste des sujets à moderer
🎸 ajout de bandeau d'infos pour inciter les utilisateurs à se connecter
🎸 paramétrage manuel : les utilisateurs anonymes ne peuvent plus poster sans modération

## Type de changement

⚠️ hotfix
🚧 technique


### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/f894a845-bd66-4f3b-bae9-92e2e390c991)
