### PR TITLE
[HOMEPAGE] mettre en avant un forum de manière optionnelle

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -435,3 +435,7 @@ PERMISSIONS_POLICY = {
     "sync-xhr": [],
     "usb": [],
 }
+
+# EXPERIMENTAL
+# ---------------------------------------
+HIGHLIGHTED_FORUM_PK = 105

--- a/lacommunaute/pages/tests/test_homepage.py
+++ b/lacommunaute/pages/tests/test_homepage.py
@@ -1,4 +1,5 @@
 import pytest  # noqa
+from django.test import override_settings
 from django.urls import reverse
 
 from lacommunaute.forum.enums import Kind as ForumKind
@@ -40,3 +41,18 @@ def test_new_topics_order(client, db):
     response = client.get(url)
     assert response.status_code == 200
     assert list(response.context_data["topics_public"]) == [topic2, topic1]
+
+
+def test_highlighted_forum(client, db):
+    forum = ForumFactory()
+    url = reverse("pages:home")
+
+    with override_settings(HIGHLIGHTED_FORUM_PK=None):
+        response = client.get(url)
+    assert "highlighted_forum" not in response.context_data
+    assert "topics_of_highlighted_forum" not in response.context_data
+
+    with override_settings(HIGHLIGHTED_FORUM_PK=forum.pk):
+        response = client.get(url)
+    assert "highlighted_forum" in response.context_data
+    assert "topics_of_highlighted_forum" in response.context_data

--- a/lacommunaute/pages/tests/test_homepage.py
+++ b/lacommunaute/pages/tests/test_homepage.py
@@ -56,3 +56,8 @@ def test_highlighted_forum(client, db):
         response = client.get(url)
     assert "highlighted_forum" in response.context_data
     assert "topics_of_highlighted_forum" in response.context_data
+
+    with override_settings(HIGHLIGHTED_FORUM_PK=999):
+        response = client.get(url)
+    assert "highlighted_forum" not in response.context_data
+    assert "topics_of_highlighted_forum" not in response.context_data

--- a/lacommunaute/pages/views.py
+++ b/lacommunaute/pages/views.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db.models import CharField
 from django.db.models.functions import Cast
@@ -99,6 +100,12 @@ class HomeView(TemplateView):
             "-updated"
         )[:4]
         context["forum"] = Forum.objects.filter(kind=ForumKind.PUBLIC_FORUM, lft=1, level=0).first()
+
+        if getattr(settings, "HIGHLIGHTED_FORUM_PK", None):
+            context["topics_of_highlighted_forum"] = Topic.objects.filter(
+                forum__pk=settings.HIGHLIGHTED_FORUM_PK
+            ).order_by("-created")[:4]
+            context["highlighted_forum"] = Forum.objects.get(pk=settings.HIGHLIGHTED_FORUM_PK)
         return context
 
 

--- a/lacommunaute/pages/views.py
+++ b/lacommunaute/pages/views.py
@@ -102,10 +102,11 @@ class HomeView(TemplateView):
         context["forum"] = Forum.objects.filter(kind=ForumKind.PUBLIC_FORUM, lft=1, level=0).first()
 
         if getattr(settings, "HIGHLIGHTED_FORUM_PK", None):
-            context["topics_of_highlighted_forum"] = Topic.objects.filter(
-                forum__pk=settings.HIGHLIGHTED_FORUM_PK
-            ).order_by("-created")[:4]
-            context["highlighted_forum"] = Forum.objects.get(pk=settings.HIGHLIGHTED_FORUM_PK)
+            if Forum.objects.filter(pk=settings.HIGHLIGHTED_FORUM_PK).exists():
+                context["topics_of_highlighted_forum"] = Topic.objects.filter(
+                    forum__pk=settings.HIGHLIGHTED_FORUM_PK
+                ).order_by("-created")[:4]
+                context["highlighted_forum"] = Forum.objects.get(pk=settings.HIGHLIGHTED_FORUM_PK)
         return context
 
 

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -123,7 +123,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="s-section__col col-12 mb-3 mb-md-5">
+                <div class="s-section__col col-12{% if highlighted_forum %} col-md-6{% endif %} mb-3 mb-md-5">
                     <div class="c-box p-0 h-100">
                         <div class="p-3 p-lg-4 bg-light">
                             <h3 class="m-0">
@@ -150,6 +150,39 @@
                         </div>
                     </div>
                 </div>
+                {% if highlighted_forum %}
+                    <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
+                        <div class="c-box p-0 h-100">
+                            <div class="p-3 p-lg-4 bg-light">
+                                <h3 class="m-0">
+                                    <i class="ri-user-line ri-lg font-weight-normal" aria-hidden="true"></i>
+                                    {{ highlighted_forum.name }}
+                                </h3>
+                            </div>
+                            <div class="px-3 px-lg-4 pt-3 pt-lg-4">
+                                <ul class="list-unstyled mb-lg-5">
+                                    {% for topic in topics_of_highlighted_forum %}
+                                        <li class="mb-3 position-relative">
+                                            <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                               class="matomo-event btn-link stretched-link"
+                                               data-matomo-category="engagement"
+                                               data-matomo-action="view"
+                                               data-matomo-option="topic">{{ topic.subject }}</a>
+                                            {% include "forum_conversation/partials/poster_light.html" with poster=topic.first_post.poster_display_name dated=topic.created only %}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                            </div>
+                            <div class="p-3 p-lg-4">
+                                <a href="{% url 'forum_extension:forum' highlighted_forum.slug highlighted_forum.pk %}"
+                                   class="btn btn-outline-primary btn-block matomo-event"
+                                   data-matomo-category="engagement"
+                                   data-matomo-action="view"
+                                   data-matomo-option="topics">{% trans "See all questions" %}</a>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Description

🎸 La home page contient par défaut 3 blocs, dont le premier contient tous les nouveaux topics de toutes les communautés publiques.
🎸 Pour mettre en avant un forum spécifique (ie xp FT), nous avons besoin de rendre visible sur la home page, un forum en particulier.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 low cost : le forum mis en avant est paramétré en dur dans `base.py`. possibilité future : gerer ce paramètre dans l'admin.
🦺 possibilité future : dynamiser la génération des blocs

### Captures d'écran (optionnel)

Home page sans forum mis en avant
![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/b5070f7f-c380-4e8b-9f9e-15cdaf6207f7)


Home page avec un forum mis en avant
![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/8cfa5a0a-570b-4f9a-bdd5-bec8a04000cd)



