### PR TITLE
Corriger le <title> du site

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -2,7 +2,6 @@ import os
 
 from dotenv import load_dotenv
 from machina import MACHINA_MAIN_STATIC_DIR, MACHINA_MAIN_TEMPLATE_DIR
-from machina.conf.settings import BASE_TEMPLATE_NAME
 
 
 load_dotenv()
@@ -231,7 +230,10 @@ COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
 COMPRESS_OFFLINE = True
 COMPRESS_OFFLINE_CONTEXT = {
     "BASE_TEMPLATE": "layouts/base.html",
-    "MACHINA_BASE_TEMPLATE_NAME": BASE_TEMPLATE_NAME,
+    # Do not import machina settings for that value. It forces evaluation
+    # of machina’s getattr(settings, "XXX", MACHINA_DEFAULT) before our
+    # settings have be defined, thus preventing our overrides.
+    "MACHINA_BASE_TEMPLATE_NAME": "_base.html",
 }
 
 # Default primary key field type

--- a/lacommunaute/pages/tests/test_homepage.py
+++ b/lacommunaute/pages/tests/test_homepage.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from lacommunaute.forum.enums import Kind as ForumKind
 from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
+from pytest_django.asserts import assertContains
 
 
 def test_context_data(client, db):
@@ -40,3 +41,8 @@ def test_new_topics_order(client, db):
     response = client.get(url)
     assert response.status_code == 200
     assert list(response.context_data["topics_public"]) == [topic2, topic1]
+
+
+def test_page_title(db, client):
+    response = client.get(reverse("pages:home"))
+    assertContains(response, "<title>Accueil- La communauté de l'inclusion</title>", html=True, count=1)


### PR DESCRIPTION
## Description

🎸 Le titre du site n’affiche plus Accueil- Machina mais Accueil- La communauté de l'inclusion.

Problème introduit dans f81390f4bef63f4c2896180fcf25fabbb2302733.

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
