### PR TITLE
[MODERATION] desapprobation d'un post avec email dejà bounced

### DIFF
--- a/lacommunaute/forum_moderation/tests/test_post_disapprove_view.py
+++ b/lacommunaute/forum_moderation/tests/test_post_disapprove_view.py
@@ -3,10 +3,22 @@ from lacommunaute.forum_conversation.factories import TopicFactory, AnonymousPos
 from lacommunaute.notification.models import BouncedEmail
 from lacommunaute.users.factories import UserFactory
 from django.urls import reverse
+from lacommunaute.notification.factories import BouncedEmailFactory
 
 
 def test_post_disapprove_view(client, db):
     disapproved_post = AnonymousPostFactory(topic=TopicFactory(approved=False))
+    client.force_login(UserFactory(is_superuser=True))
+    response = client.post(
+        reverse("forum_moderation_extension:disapprove_queued_post", kwargs={"pk": disapproved_post.pk})
+    )
+    assert response.status_code == 302
+    assert BouncedEmail.objects.get(email=disapproved_post.username)
+
+
+def test_post_disapprove_view_with_existing_bounced_email(client, db):
+    disapproved_post = AnonymousPostFactory(topic=TopicFactory(approved=False))
+    BouncedEmailFactory(email=disapproved_post.username)
     client.force_login(UserFactory(is_superuser=True))
     response = client.post(
         reverse("forum_moderation_extension:disapprove_queued_post", kwargs={"pk": disapproved_post.pk})

--- a/lacommunaute/forum_moderation/views.py
+++ b/lacommunaute/forum_moderation/views.py
@@ -17,10 +17,15 @@ class TopicDeleteView(BaseTopicDeleteView):
 class PostDisapproveView(BasePostDisapproveView):
     def post(self, request, *args, **kwargs):
         post = self.get_object()
-        username = post.username
-        if username:
-            BouncedEmail.objects.create(email=username, reason="Post disapproved")
-            messages.success(
-                self.request, "l'adresse email de l'utilisateur a été ajoutée à la liste des emails bloqués."
-            )
+        if post.username:
+            if BouncedEmail.objects.filter(email=post.username).exists():
+                messages.warning(
+                    self.request,
+                    "l'adresse email de l'utilisateur est déjà dans la liste des emails bloqués.",
+                )
+            else:
+                BouncedEmail.objects.create(email=post.username, reason="Post disapproved")
+                messages.warning(
+                    self.request, "l'adresse email de l'utilisateur a été ajoutée à la liste des emails bloqués."
+                )
         return self.disapprove(request, *args, **kwargs)


### PR DESCRIPTION
## Description

🎸 Lors de la desapprobation d'un `post`, l'email de l'utilisateur anonyme est ajouté dans `BouncedEmail`. 
🎸 `BouncedEmail` contient une contrainte d'unicité sur l'email.
🎸 Correction de la surcharge de la vue `PostDisapproveView`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique
