### PR TITLE
[FORUM PROFILE] afficher les contributeurs authentifiés les plus actifs sur les 30 derniers jours

### DIFF
--- a/lacommunaute/forum_member/models.py
+++ b/lacommunaute/forum_member/models.py
@@ -1,8 +1,25 @@
+from dateutil.relativedelta import relativedelta
+from django.db import models
+from django.utils import timezone
 from machina.apps.forum_member.abstract_models import AbstractForumProfile
 
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 
 
+class ForumProfileQuerySet(models.QuerySet):
+    def power_users(self):
+        return (
+            self.filter(user__posts__created__gte=timezone.now() - relativedelta(days=30))
+            .annotate(user_posts_count=models.Count("user__posts"))
+            .filter(user_posts_count__gte=3)
+            .order_by("-user_posts_count")
+            .select_related("user")
+            .prefetch_related("user__posts")
+        )
+
+
 class ForumProfile(AbstractForumProfile):
+    objects = ForumProfileQuerySet().as_manager()
+
     def __str__(self):
         return get_forum_member_display_name(self.user)

--- a/lacommunaute/forum_member/models.py
+++ b/lacommunaute/forum_member/models.py
@@ -1,5 +1,8 @@
 from machina.apps.forum_member.abstract_models import AbstractForumProfile
 
+from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
+
 
 class ForumProfile(AbstractForumProfile):
-    pass
+    def __str__(self):
+        return get_forum_member_display_name(self.user)

--- a/lacommunaute/forum_member/tests/tests_models.py
+++ b/lacommunaute/forum_member/tests/tests_models.py
@@ -1,9 +1,53 @@
 import pytest  # noqa
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 
+from lacommunaute.forum_conversation.factories import (  # noqa
+    AnonymousPostFactory,
+    AnonymousTopicFactory,
+    PostFactory,
+    TopicFactory,
+)
 from lacommunaute.forum_member.factories import ForumProfileFactory
+from lacommunaute.forum_member.models import ForumProfile
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 
 
 def test_get_forum_member_display_name(db):
     forum_profile = ForumProfileFactory()
     assert forum_profile.__str__() == get_forum_member_display_name(forum_profile.user)
+
+
+def test_powerusers_forumprofile_queryset(db):
+    # anonymous user with 3 posts within the last 30 days
+    topic1 = AnonymousTopicFactory(with_post=True)
+    AnonymousPostFactory.create_batch(2, topic=topic1, username=topic1.first_post.username)
+
+    # authenticated user with 2 posts within the last 30 days
+    forum_profile1 = ForumProfileFactory()
+    topic2 = TopicFactory(with_post=True, poster=forum_profile1.user)
+    PostFactory(topic=topic2, poster=forum_profile1.user)
+
+    # authenticated user with 3 post before the last 30 days
+    forum_profile2 = ForumProfileFactory()
+    topic3 = TopicFactory(with_post=True, poster=forum_profile2.user)
+    PostFactory(topic=topic3, poster=forum_profile2.user)
+    for post in topic3.posts.all():
+        post.created = timezone.now() - relativedelta(days=31)
+        post.save()
+
+    assert ForumProfile.objects.power_users().count() == 0
+
+    # authenticated user with 3 posts within the last 30 days
+    poweruser = ForumProfileFactory()
+    topic4 = TopicFactory(with_post=True, poster=poweruser.user)
+    PostFactory.create_batch(2, topic=topic4, poster=poweruser.user)
+
+    # authenticated user with more than 3 posts within the last 30 days
+    bigpoweruser = ForumProfileFactory()
+    topic5 = TopicFactory(with_post=True, poster=bigpoweruser.user)
+    PostFactory.create_batch(20, topic=topic5, poster=bigpoweruser.user)
+
+    assert bigpoweruser == ForumProfile.objects.power_users().first()
+    assert poweruser == ForumProfile.objects.power_users().last()
+    assert ForumProfile.objects.power_users().count() == 2

--- a/lacommunaute/forum_member/tests/tests_models.py
+++ b/lacommunaute/forum_member/tests/tests_models.py
@@ -1,0 +1,9 @@
+import pytest  # noqa
+
+from lacommunaute.forum_member.factories import ForumProfileFactory
+from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
+
+
+def test_get_forum_member_display_name(db):
+    forum_profile = ForumProfileFactory()
+    assert forum_profile.__str__() == get_forum_member_display_name(forum_profile.user)

--- a/lacommunaute/forum_member/urls.py
+++ b/lacommunaute/forum_member/urls.py
@@ -5,6 +5,7 @@ from lacommunaute.forum_member.views import (
     ForumProfileUpdateView,
     JoinForumFormView,
     JoinForumLandingView,
+    LeaderBoardListView,
     ModeratorProfileListView,
 )
 
@@ -17,4 +18,5 @@ urlpatterns = [
     path("forum/<str:slug>-<int:pk>/", ModeratorProfileListView.as_view(), name="forum_profiles"),
     path("join-forum-landing/<uuid:token>/", JoinForumLandingView.as_view(), name="join_forum_landing"),
     path("join-forum/<uuid:token>/", JoinForumFormView.as_view(), name="join_forum_form"),
+    path("leaderboard/", LeaderBoardListView.as_view(), name="leaderboard"),
 ]

--- a/lacommunaute/forum_member/views.py
+++ b/lacommunaute/forum_member/views.py
@@ -130,3 +130,18 @@ class JoinForumFormView(LoginRequiredMixin, FormView):
                 "pk": self.forum.pk,
             },
         )
+
+
+class LeaderBoardListView(ListView):
+    model = ForumProfile
+    template_name = "forum_member/profiles.html"
+    context_object_name = "forum_profiles"
+    paginate_by = 78
+
+    def get_queryset(self):
+        return ForumProfile.objects.power_users()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["subtitle"] = "Contributeurs authentifiés les plus actifs sur les 30 derniers jours"
+        return context

--- a/lacommunaute/templates/forum_member/forum_profile_detail.html
+++ b/lacommunaute/templates/forum_member/forum_profile_detail.html
@@ -2,12 +2,12 @@
 {% load i18n %}
 {% load forum_member_tags %}
 {% block sub_title %}
-    {% blocktrans with username=profile.user|forum_member_display_name %}{{ username }} profile{% endblocktrans %}
+    Profil de {{ profile.user|forum_member_display_name }}
 {% endblock sub_title %}
 {% block content %}
     <div class="mb-3 row">
         <div class="col-12">
-            <h1>{% blocktrans with username=profile.user|forum_member_display_name %}{{ username }} profile{% endblocktrans %}</h1>
+            <h1>Profil de {{ profile.user|forum_member_display_name }}</h1>
         </div>
     </div>
     <div class="row profile">
@@ -15,12 +15,11 @@
             <div class="mb-3 profile-sidebar">
                 <div class="card">
                     <div class="profile-avatar">{% include "partials/avatar.html" with profile=profile show_placeholder=True %}</div>
-                    <div class="profile-username">
-                        <h3 class="my-3 text-center text-muted">{{ profile.user|forum_member_display_name }}</h3>
-                    </div>
-                    <div class="profile-signature">
-                        <p class="my-3 text-center text-muted">{{ profile.signature }}</p>
-                    </div>
+                    {% if profile.signature %}
+                        <div class="profile-signature">
+                            <p class="my-3 text-center text-muted">{{ profile.signature }}</p>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
             {% if profile.user == request.user %}

--- a/lacommunaute/templates/forum_member/profiles.html
+++ b/lacommunaute/templates/forum_member/profiles.html
@@ -9,7 +9,7 @@
                     <h1 class="s-title-01__title h1">
                         <strong>Membres</strong>
                     </h1>
-                    <h2 class="h2">Liste des membres de la communauté.</h2>
+                    <h2 class="h2">{{ subtitle|default:"Liste des membres" }}</h2>
                 </div>
             </div>
         </div>
@@ -22,12 +22,9 @@
                         {% for forum_profile in forum_profiles %}
                             <div class="col">
                                 <div class="card">
-                                    {% if forum_profile.avatar %}
-                                        <img class="avatar card-img-top" src="{{ forum_profile.avatar }}" alt="{{ forum_profile.user.get_full_name }}">
-                                    {% endif %}
                                     <div class="card-body">
                                         <h3 class="h5 card-title">
-                                            <a href="{% url 'members:profile' username=forum_profile.user.username %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="member">{{ forum_profile.user.get_full_name }}</a>
+                                            <a href="{% url 'members:profile' username=forum_profile.user.username %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="member">{{ forum_profile }}</a>
                                         </h3>
                                         {% if forum_profile.signature %}<p class="card-text">{{ forum_profile.signature }}</p>{% endif %}
                                     </div>
@@ -39,6 +36,11 @@
                             </div>
                         {% endfor %}
                     </div>
+                    {% if page_obj.has_previous or page_obj.has_next %}
+                        {% with pagination_size="pagination-sm justify-content-center mt-5" %}
+                            {% include "partials/pagination.html" %}
+                        {% endwith %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/lacommunaute/templates/partials/footer.html
+++ b/lacommunaute/templates/partials/footer.html
@@ -24,6 +24,9 @@
                         <li>
                             <a href="{% url 'search:index' %}">{% trans "Search forums" %}</a>
                         </li>
+                        <li>
+                            <a href="{% url 'members:leaderboard' %}">Leaderboard</a>
+                        </li>
                     </ul>
                 </div>
                 <div class="s-footer-quick__col col-12 col-md-6 col-lg-auto">


### PR DESCRIPTION
## Description

🎸 Afficher les `forum_profile` qui ont posté au moins 3 `post` sur les 3 derniers jours dans une page type `leaderboard`
🎸 Les `posts` anonymes ne sont pas pris en compte.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Réutilisation du gabarit `profiles.html` en rendant le sous-titre paramétrable.
🦺 Ne pas afficher les emails des `forum_profile`

### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/c0a93b74-cf10-4214-bbc3-79ff11f4329d)
