### PR TITLE
[MODERATION] bloquer les messages de spams

### DIFF
--- a/lacommunaute/forum_conversation/forms.py
+++ b/lacommunaute/forum_conversation/forms.py
@@ -14,7 +14,7 @@ class CreateUpdatePostMixin:
         cleaned_data = super().clean()
         if "content" in cleaned_data:
             post = check_post_approbation(
-                Post(username=cleaned_data.get("username", None), content=cleaned_data.get("content"))
+                Post(username=cleaned_data.get("username"), content=cleaned_data.get("content"))
             )
             if not post.approved:
                 self.add_error(None, "Votre message ne respecte pas les règles de la communauté.")

--- a/lacommunaute/forum_conversation/forms.py
+++ b/lacommunaute/forum_conversation/forms.py
@@ -8,7 +8,7 @@ from taggit.models import Tag
 from lacommunaute.forum_moderation.utils import check_post_approbation
 
 
-class UpdatePostMixin:
+class CreateUpdatePostMixin:
     def update_post(self, post):
         if self.user.is_anonymous:
             post.username = self.cleaned_data["username"]
@@ -19,7 +19,7 @@ class UpdatePostMixin:
         post = check_post_approbation(post)
 
 
-class PostForm(UpdatePostMixin, AbstractPostForm):
+class PostForm(CreateUpdatePostMixin, AbstractPostForm):
     subject = CharField(widget=HiddenInput(), required=False)
 
     def create_post(self):
@@ -33,7 +33,7 @@ class PostForm(UpdatePostMixin, AbstractPostForm):
         return post
 
 
-class TopicForm(UpdatePostMixin, AbstractTopicForm):
+class TopicForm(CreateUpdatePostMixin, AbstractTopicForm):
     tags = ModelMultipleChoiceField(
         label="", queryset=Tag.objects.all(), widget=CheckboxSelectMultiple, required=False
     )

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -14,7 +14,6 @@ from lacommunaute.forum_conversation.enums import Filters
 from lacommunaute.forum_conversation.forms import PostForm, TopicForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.shortcuts import can_certify_post, get_posts_of_a_topic_except_first_one
-from lacommunaute.forum_moderation.utils import check_post_approbation
 
 
 logger = logging.getLogger(__name__)
@@ -27,12 +26,6 @@ track_handler = TrackingHandler()
 class FormValidMixin:
     def form_valid(self, *args, **kwargs):
         valid = super().form_valid(*args, **kwargs)
-
-        self.forum_post = check_post_approbation(self.forum_post)
-        if self.forum_post.is_topic_head:
-            self.forum_post.topic.approved = self.forum_post.approved
-            self.forum_post.topic.save()
-        self.forum_post.save()
 
         track_handler.mark_topic_read(self.forum_post.topic, self.request.user)
         return valid

--- a/lacommunaute/forum_conversation/views_htmx.py
+++ b/lacommunaute/forum_conversation/views_htmx.py
@@ -155,7 +155,11 @@ class PostFeedCreateView(PermissionRequiredMixin, View):
                 },
             )
 
-        return render(request, "500.html", status=500)
+        return render(
+            request,
+            "forum_conversation/partials/post_feed_form_errors.html",
+            context={"topic": self.topic, "post_form": form},
+        )
 
     def get_controlled_object(self):
         return self.get_topic()

--- a/lacommunaute/forum_conversation/views_htmx.py
+++ b/lacommunaute/forum_conversation/views_htmx.py
@@ -11,7 +11,6 @@ from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import CertifiedPost, Post, Topic
 from lacommunaute.forum_conversation.shortcuts import can_certify_post, get_posts_of_a_topic_except_first_one
-from lacommunaute.forum_moderation.utils import check_post_approbation
 
 
 logger = logging.getLogger(__name__)
@@ -142,7 +141,6 @@ class PostFeedCreateView(PermissionRequiredMixin, View):
             post = form.save()
             # set count to zero by default. no need to annotate queryset when saving new post
             post.upvotes_count = 0
-            post = check_post_approbation(post)
             post.save()
 
             track_handler.mark_topic_read(self.topic, request.user)

--- a/lacommunaute/forum_moderation/utils.py
+++ b/lacommunaute/forum_moderation/utils.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from langdetect import detect
+from machina.models.fields import render_func
 from markdown2 import Markdown
 
 from lacommunaute.forum_moderation.models import BlockedDomainName, BlockedEmail
@@ -8,14 +9,17 @@ from lacommunaute.forum_moderation.models import BlockedDomainName, BlockedEmail
 def check_post_approbation(post):
     """
     Check if a post should be approved or not
+    Force markdown rendering to check for HTML tags
+    because the post is not save yet
     """
+    rendered = render_func(post.content.raw)
 
     conditions = [
         (
             post.username and BlockedDomainName.objects.filter(domain=post.username.split("@")[-1]).exists(),
             "Blocked Domain detected",
         ),
-        (Markdown.html_removed_text_compat in post.content.rendered, "HTML tags detected"),
+        (Markdown.html_removed_text_compat in rendered, "HTML tags detected"),
         (detect(post.content.raw) not in settings.LANGUAGE_CODE, "Alternative Language detected"),
         (post.username and BlockedEmail.objects.filter(email=post.username).exists(), "Blocked Email detected"),
     ]

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
@@ -2,7 +2,7 @@
 {% load forum_permission_tags %}
 {% get_permission 'can_add_post' topic request.user as user_can_add_post %}
 {% if user_can_add_post %}
-    <div class="collapse" id="collapsePost{{ topic.pk }}">
+    <div class="collapse{% if show %} show{% endif %}" id="collapsePost{{ topic.pk }}">
         <div class="card mb-3{% if inline %} ms-3{% endif %}">
             <div class="card-body">
                 <div class="row">

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_collapsable.html
@@ -16,11 +16,7 @@
                               data-matomo-option="post">
                             {% csrf_token %}
                             {% if post_form.non_field_errors %}
-                                {% for error in post_form.non_field_errors %}
-                                    <div class="alert alert-danger">
-                                        <i class="icon-exclamation-sign"></i> {{ error }}
-                                    </div>
-                                {% endfor %}
+                                {% for error in post_form.non_field_errors %}<div class="alert alert-danger">{{ error }}</div>{% endfor %}
                             {% endif %}
                             {% include "partials/form_field.html" with field=post_form.content id=topic.pk %}
                             {% if post_form.username %}

--- a/lacommunaute/templates/forum_conversation/partials/post_feed_form_errors.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed_form_errors.html
@@ -1,0 +1,3 @@
+<div id="postinfeedarea{{ topic.pk }}">
+    {% include "forum_conversation/partials/post_feed_form_collapsable.html" with topic=topic post_form=post_form inline=1 show=True %}
+</div>


### PR DESCRIPTION
## Description

🎸 Empecher l'enregistrement des messages non conformes au lieu de les désapprouver puis de les reprendre manuellement.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique

### Points d'attention

🦺 La vue htmx de création de `post` dans le fil des messages gère désormais l'affichage des erreurs dans le formulaire au lieu de générer une erreur 500.
🦺 Le contrôle du contenu des messages est centralisé dans `CreateUpdatePostMixin`
🦺 Le `rendering` du champ `content` du modèle `Post` n'est pas encore executé lors de l'execution de la méthode `clean` du formulaire. L'extraction du contenu en markdown est ajouté en début de méthode `check_post_approbation`

### Captures d'écran (optionnel)

Affichage d'une erreur dans les formulaires classic django : `CreateView` et `UpdateView`

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/f89e1e2e-2124-493d-9686-7fdc96f0cdc9)

Affichage d'une erreur dans le formulaire `htmx` `PostFeedCreateView`

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/a5db8bec-faae-44ab-b77b-df91c60f4aab)
