### PR TITLE
[HOMEPAGE] afficher les évènements à venir

### DIFF
--- a/lacommunaute/pages/views.py
+++ b/lacommunaute/pages/views.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from django.utils.dateformat import format
 from django.views.generic.base import TemplateView
 
+from lacommunaute.event.models import Event
 from lacommunaute.forum.enums import Kind as ForumKind
 from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.models import Topic
@@ -99,6 +100,7 @@ class HomeView(TemplateView):
             "-updated"
         )[:4]
         context["forum"] = Forum.objects.filter(kind=ForumKind.PUBLIC_FORUM, lft=1, level=0).first()
+        context["upcoming_events"] = Event.objects.filter(date__gte=timezone.now()).order_by("date")[:4]
         return context
 
 

--- a/lacommunaute/templates/event/event_detail.html
+++ b/lacommunaute/templates/event/event_detail.html
@@ -22,17 +22,7 @@
                             <div class="row">
                                 <div class="col-12 post-content-wrapper mb-1">
                                     <h2 class="mt-3">{{ event.name }}</h2>
-                                    <h3>
-                                        {% if event.date == event.end_date %}
-                                            {% blocktrans trimmed with date=event.date time=event.time end_time=event.end_time %}
-                                                On {{ date }} from {{ time }} to {{ end_time }}
-                                            {% endblocktrans %}
-                                        {% else %}
-                                            {% blocktrans trimmed with date=event.date end_date=event.end_date time=event.time end_time=event.end_time %}
-                                                From {{ date }} {{ time }} to {{ end_date }} {{ end_time }}
-                                            {% endblocktrans %}
-                                        {% endif %}
-                                    </h3>
+                                    <h3>{% include 'event/partials/event_date.html' with event=event only %}</h3>
                                 </div>
                             </div>
                         </div>

--- a/lacommunaute/templates/event/partials/event_date.html
+++ b/lacommunaute/templates/event/partials/event_date.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% if event.date == event.end_date %}
+    {% blocktrans trimmed with date=event.date time=event.time end_time=event.end_time %}
+        On {{ date }} from {{ time }} to {{ end_time }}
+    {% endblocktrans %}
+{% else %}
+    {% blocktrans trimmed with date=event.date end_date=event.end_date time=event.time end_time=event.end_time %}
+        From {{ date }} {{ time }} to {{ end_date }} {{ end_time }}
+    {% endblocktrans %}
+{% endif %}

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -15,6 +15,7 @@
     {% url 'forum_conversation_extension:topics' as publicforum_url %}
     {% url 'forum_conversation_extension:newsfeed' as newsfeed_url %}
     {% url 'forum_extension:documentation' as documentation_url %}
+    {% url 'event:current' as event_url %}
     <section class="s-hero-title-01--communaute">
         <div class="s-hero-title-01__container container">
             <div class="s-hero-title-01__row row align-items-center">
@@ -90,7 +91,7 @@
                         <div class="p-3 p-lg-4 bg-light">
                             <h3 class="m-0">
                                 <i class="ri-article-line ri-lg font-weight-normal" aria-hidden="true"></i>
-                                Les dernières fiches thématiques
+                                Les fiches thématiques mises à jour
                             </h3>
                         </div>
                         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
@@ -110,7 +111,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="s-section__col col-12 mb-3 mb-md-5">
+                <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
                     <div class="c-box p-0 h-100">
                         <div class="p-3 p-lg-4 bg-light">
                             <h3 class="m-0">
@@ -134,6 +135,31 @@
                         </div>
                         <div class="p-3 p-lg-4">
                             <a href="{{ newsfeed_url }}" class="btn btn-outline-primary btn-block matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="news">{% trans "See all news" %}</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
+                    <div class="c-box p-0 h-100">
+                        <div class="p-3 p-lg-4 bg-light">
+                            <h3 class="m-0">
+                                <i class="ri-calendar-event-fill ri-lg font-weight-normal" aria-hidden="true"></i>
+                                Les évènements à venir
+                            </h3>
+                        </div>
+                        <div class="px-3 px-lg-4 pt-3 pt-lg-4">
+                            <ul class="list-unstyled mb-lg-5">
+                                {% for event in upcoming_events %}
+                                    <li class="mb-3 position-relative">
+                                        <a href="{% url 'event:detail' event.pk %}" class="matomo-event btn-link stretched-link" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="event">
+                                            {{ event.name }}
+                                        </a>
+                                        <small class="text-muted">{% include 'event/partials/event_date.html' with event=event only %}</small>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                        <div class="p-3 p-lg-4">
+                            <a href="{{ event_url }}" class="btn btn-outline-primary btn-block matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="events">Voir tous les évènements</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Description

🎸 Ajouter un quatrième cadre avec les 4 prochains évènements, leur date et un lien vers la page de l'évènement
🎸 Ajouter un lien vers la page des évènements du mois en cours

## Type de changement
🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/536c6e94-ae6c-4b8c-a647-3874526a8551)
