### PR TITLE
[FORUM] suppression des liens d'invitations dans des forums privés

### DIFF
--- a/lacommunaute/forum_member/forms.py
+++ b/lacommunaute/forum_member/forms.py
@@ -5,14 +5,6 @@ from lacommunaute.forum_member.enums import ActiveSearch, Regions
 from lacommunaute.forum_member.models import ForumProfile
 
 
-class JoinForumForm(forms.Form):
-    invitation_token = forms.HiddenInput()
-
-    def join_forum(self):
-        if not self.forum.members_group.user_set.filter(id=self.user.id).exists():
-            self.forum.members_group.user_set.add(self.user)
-
-
 class ForumProfileForm(BaseForumProfileForm):
     cv = forms.FileField(label="Curriculum Vitae", required=False)
     linkedin = forms.URLField(label="Lien vers votre profil LinkedIn", required=False)

--- a/lacommunaute/forum_member/tests/tests_view.py
+++ b/lacommunaute/forum_member/tests/tests_view.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.contrib.auth.models import Group
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -12,7 +10,7 @@ from lacommunaute.forum_member.factories import ForumProfileFactory
 from lacommunaute.forum_member.models import ForumProfile
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.forum_member.views import ForumProfileUpdateView
-from lacommunaute.users.factories import DEFAULT_PASSWORD, UserFactory
+from lacommunaute.users.factories import UserFactory
 
 
 PermissionHandler = get_class("forum_permission.handler", "PermissionHandler")
@@ -104,19 +102,6 @@ class ModeratorProfileListView(TestCase):
         self.assertEqual(response.context["forum_profiles"][0].user.first_name, "bob_is_a_member")
         self.assertContains(response, "1 membre")
 
-    def test_join_url_is_shown(self):
-        self.client.force_login(self.profile.user)
-        response = self.client.get(self.url)
-        self.assertContains(
-            response,
-            reverse(
-                "members:join_forum_form",
-                kwargs={
-                    "token": self.forum.invitation_token,
-                },
-            ),
-        )
-
     def test_queries_number(self):
         profiles = ForumProfileFactory.create_batch(10)
         self.forum.members_group.user_set.add(*[profile.user for profile in profiles])
@@ -125,72 +110,6 @@ class ModeratorProfileListView(TestCase):
         self.client.force_login(self.profile.user)
         with self.assertNumQueries(11):
             self.client.get(self.url)
-
-
-class JoinForumLandingView(TestCase):
-    def test_token_doesnt_exists(self):
-        user = UserFactory()
-        wrong_token = uuid.uuid4()
-        self.client.login(username=user.username, password=DEFAULT_PASSWORD)
-        url = reverse("members:join_forum_form", kwargs={"token": wrong_token})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
-        self.assertTemplateUsed(response, "404.html")
-
-
-class JoinForumFormViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.token = uuid.uuid4()
-        cls.forum = create_forum(invitation_token=cls.token)
-        cls.forum.members_group = Group.objects.create(name="members")
-        cls.forum.save()
-        cls.user = UserFactory()
-        cls.url = reverse("members:join_forum_form", kwargs={"token": cls.token})
-
-        cls.perm_handler = PermissionHandler()
-        assign_perm("can_read_forum", cls.forum.members_group, cls.forum)
-        assign_perm("can_see_forum", cls.forum.members_group, cls.forum)
-
-    def test_anonymous_redirection(self):
-        response = self.client.get(self.url)
-        self.assertRedirects(
-            response, reverse("members:join_forum_landing", kwargs={"token": self.token}) + "?next=" + self.url
-        )
-
-    def test_token_doesnt_exists(self):
-        wrong_token = uuid.uuid4()
-        self.client.force_login(self.user)
-        url = reverse("members:join_forum_form", kwargs={"token": wrong_token})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
-        self.assertTemplateUsed(response, "404.html")
-
-    def test_get(self):
-        self.client.force_login(self.user)
-        response = self.client.get(self.url)
-        self.assertContains(response, self.forum.name, status_code=200)
-
-    def test_post(self):
-        self.client.force_login(self.user)
-        response = self.client.post(self.url)
-        self.assertRedirects(
-            response,
-            reverse(
-                "forum_extension:forum",
-                kwargs={
-                    "slug": self.forum.slug,
-                    "pk": self.forum.pk,
-                },
-            ),
-        )
-        self.assertTrue(self.forum.members_group.user_set.filter(id=self.user.id).exists())
-
-    def test_already_in_group(self):
-        self.forum.members_group.user_set.add(self.user)
-        self.client.force_login(self.user)
-        self.client.post(self.url)
-        self.assertTrue(self.forum.members_group.user_set.filter(id=self.user.id).exists())
 
 
 class TestLeaderBoardListView:

--- a/lacommunaute/forum_member/urls.py
+++ b/lacommunaute/forum_member/urls.py
@@ -3,8 +3,6 @@ from django.urls import path
 from lacommunaute.forum_member.views import (
     ForumProfileDetailView,
     ForumProfileUpdateView,
-    JoinForumFormView,
-    JoinForumLandingView,
     LeaderBoardListView,
     ModeratorProfileListView,
     SeekersListView,
@@ -17,8 +15,6 @@ urlpatterns = [
     path("profile/edit/", ForumProfileUpdateView.as_view(), name="profile_update"),
     path("profile/<str:username>/", ForumProfileDetailView.as_view(), name="profile"),
     path("forum/<str:slug>-<int:pk>/", ModeratorProfileListView.as_view(), name="forum_profiles"),
-    path("join-forum-landing/<uuid:token>/", JoinForumLandingView.as_view(), name="join_forum_landing"),
-    path("join-forum/<uuid:token>/", JoinForumFormView.as_view(), name="join_forum_form"),
     path("leaderboard/", LeaderBoardListView.as_view(), name="leaderboard"),
     path("seekers/", SeekersListView.as_view(), name="seekers"),
 ]

--- a/lacommunaute/templates/forum_member/moderator_profiles.html
+++ b/lacommunaute/templates/forum_member/moderator_profiles.html
@@ -43,34 +43,6 @@
                             {% endwith %}
                         </div>
                     </div>
-                    <div class="row mt-5 mb-5">
-                        <div class="col-12">
-                            <div class="form-group">
-                                <label for="validationLink01">Lier pour inviter de nouveaux membres</label>
-                                <div class="input-group">
-                                    <input type="text"
-                                           class="form-control"
-                                           name="validationLink01"
-                                           value="{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'members:join_forum_form' forum.invitation_token %}"
-                                           aria-describedby="basic-addon">
-                                    <div class="input-group-text p-0">
-                                        <button class="btn btn-link btn-ico"
-                                                type="button"
-                                                id="basic-addon"
-                                                data-bs-clipboard="copy"
-                                                data-bs-toggle="tooltip"
-                                                data-bs-placement="top"
-                                                data-bs-trigger="manual"
-                                                title=""
-                                                data-bs-original-title="Lien copié!">
-                                            <i class="ri-file-copy-line ri-lg" aria-hidden="true"></i>
-                                            <span>Copier</span>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
             </div>
         </div>

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -852,15 +852,6 @@ msgstr "S'inscrire"
 msgid "Login"
 msgstr "Se connecter"
 
-#: lacommunaute/templates/forum_member/join_forum_form.html: 32
-#, python-format
-msgid "Join forum %(name)s"
-msgstr "Vous êtes invité à rejoindre la thématique %(name)s"
-
-#: lacommunaute/templates/forum_member/join_forum_form.html: 60
-msgid "Join forum"
-msgstr "Rejoindre la thématique"
-
 #: lacommunaute/templates/pages/home.html:84
 msgid "Go to this forum"
 msgstr "Accéder à cette thématique"


### PR DESCRIPTION
## Description

🎸 Les forums privés sont dépréciés. Le mécanisme d'invitation n'est plus maintenu.

## Type de changement

🚧 technique

### Points d'attention

🦺 retrait de code mort pour alléger la dette technique

