### PR TITLE
[POST] proteger les underscores dans les urls

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -330,6 +330,10 @@ if _sentry_dsn:
 # WIDGETS
 # ---------------------------------------
 MACHINA_MARKUP_WIDGET = "lacommunaute.forum_conversation.widgets.MarkdownTextareaWidget"
+MACHINA_MARKUP_LANGUAGE = (
+    "machina.core.markdown.markdown",
+    {"safe_mode": True, "extras": {"break-on-newline": True, "code-friendly": True, "nofollow": True}},
+)
 
 # Django sites framework
 SITE_ID = 1


### PR DESCRIPTION
## Description

🎸 Machina s'appuie sur la librairie `markdown2` pour le rendu des contenus des messages (`post.content`)
🎸 L'avantage principal est de nettoyer le texte en remplaçant le code html saisi par l'utilisateur, par `[HTML_REMOVED`]
🎸 Cette substitution est utiliser dans la protection contre les spams.

🦺 Cependant, `markdown2` converti les `_` en balise markdown (`<em>`), ayant pour effet de casser le traitement de l'urlizer sur une url contenant des underscore.
🦺 L'ajout du package `code-friendly` dans la configuration de `markdown2` résout ce problème.

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

## point d'attention 

* Le setup par défaut des settings de `machina` pour `MACHINA_MARKUP_LANGUAGE`
est `('machina.core.markdown.markdown', {'safe_mode': True, 'extras': {'break-on-newline': True}})`
* La surcharge de ce setup dans lacommunaute necessite de reprendre toute la conf initiale plus les extra-packages désirés

* Le package `nofollow` est ajouté à l'occasion, bien que passé en paramètre dans l'appel à `urlize` dans la méthode `urlizetrunc_target_blank`
