### PR TITLE
[DOCUMENTATION] création de la premiere fiche de la catégorie (fix)

### DIFF
--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -124,8 +124,6 @@
                 </div>
             </div>
         </section>
-    {% endif %}
-    {% if forum.is_forum %}
         <section class="s-tabs-01">
             <div class="s-tabs-01__container container">
                 <div class="s-tabs-01__row row">

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -10,7 +10,6 @@
 {% block meta_description %}
     {{ forum.short_description }}
 {% endblock meta_description %}
-"
 {% block content %}
     {% get_permission 'can_add_topic' forum request.user as user_can_add_topic %}
     <section class="s-title-01 mt-lg-5">

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -163,5 +163,15 @@
                 </div>
             </div>
         </section>
+    {% elif forum.is_category and user.is_superuser %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="s-section__col col-12">
+                        <a href="{% url 'forum_extension:create_subcategory' forum.pk %}" aria-label="Ajouter une fiche pratique" role="button" class="btn btn-outline-primary">Ajouter une fiche pratique</a>
+                    </div>
+                </div>
+            </div>
+        </section>
     {% endif %}
 {% endblock content %}

--- a/lacommunaute/templates/forum/forum_list.html
+++ b/lacommunaute/templates/forum/forum_list.html
@@ -73,13 +73,6 @@
                 </div>
             {% endfor %}
         </div>
-        {% if user.is_superuser %}
-            <div class="row mt-4">
-                <div class="col-12">
-                    <a href="{% url 'forum_extension:create_subcategory' forum_contents.top_nodes.0.obj.parent.pk %}" aria-label="Ajouter une fiche pratique" role="button" class="btn btn-outline-primary">Ajouter une fiche pratique</a>
-                </div>
-            </div>
-        {% endif %}
     {% else %}
         <ul class="list-group mb-3 mb-md-5">
             {% for node in forum_contents.top_nodes %}


### PR DESCRIPTION
## Description

🎸 Corriger l'affichage du bouton "ajouter une fiche pratique" quand la catégorie n'en contient pas encore

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).


### Captures d'écran (optionnel)

Catégorie sans fiche pratique

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/204beb44-2db7-4155-8c77-b9b8f0d877df)

Catégorie avec fiches pratiques existantes

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/42b1d7c6-6a9e-4fd9-a956-940c02e07631)

