### PR TITLE
feat(poster): désambiguer la mention du forum, de celle des tags

### DIFF
--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -1,0 +1,46 @@
+# serializer version: 1
+# name: TestPosterTemplate.test_topic_from_other_public_forum_in_topics_view[topic_from_other_public_forum_in_topics_view]
+  '''
+  <small class="text-muted poster-infos">
+      Par :
+              
+                  
+                  <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="member" href="/members/profile/poster_username/">
+                      Alan T.
+                  </a>,
+              
+              
+                  dans <a href="forum_url">Abby's Forum</a>,
+      il y a 0 minute
+      
+  </small>
+  '''
+# ---
+# name: TestPosterTemplate.test_topic_in_its_own_public_forum[topic_in_its_own_public_forum]
+  '''
+  <small class="text-muted poster-infos">
+      Par :
+              
+                  
+                  <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="member" href="/members/profile/poster_username/">
+                      Dermot T.
+                  </a>,
+      il y a 0 minute
+      
+  </small>
+  '''
+# ---
+# name: TestPosterTemplate.test_topic_in_topics_view[topic_in_topics_view]
+  '''
+  <small class="text-muted poster-infos">
+      Par :
+              
+                  
+                  <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="member" href="/members/profile/poster_username/">
+                      Jeff B.
+                  </a>,
+      il y a 0 minute
+      
+  </small>
+  '''
+# ---

--- a/lacommunaute/templates/forum_conversation/partials/poster.html
+++ b/lacommunaute/templates/forum_conversation/partials/poster.html
@@ -5,7 +5,7 @@
     {% load forum_permission_tags %}
     {% get_permission 'can_edit_post' post request.user as user_can_edit_post %}
 {% endif %}
-<small class="text-muted">
+<small class="text-muted poster-infos">
     {% spaceless %}
         {% with poster=post.poster_display_name %}
             Par :
@@ -16,6 +16,9 @@
                 </a>,
             {% else %}
                 {{ poster }},
+            {% endif %}
+            {% if forum and forum != topic.forum %}
+                dans <a href="{% url 'forum_extension:forum' topic.forum.slug topic.forum.pk %}">{{ topic.forum }}</a>,
             {% endif %}
         {% endwith %}
     {% endspaceless %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -42,13 +42,10 @@
                         <div class="card-body pt-0">
                             <div class="row">
                                 <div class="col-12 post-content-wrapper mb-1">
-                                    {% include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True %}
+                                    {% include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True forum=forum %}
                                 </div>
                                 <div class="col-12 post-content mb-3">
                                     {% include "forum_conversation/partials/topic_tags.html" with tags=topic.tags.all %}
-                                    {% if forum != topic.forum %}
-                                        <a href="{% url 'forum_extension:forum' topic.forum.slug topic.forum.pk %}"><span class="badge badge-xs rounded-pill bg-info-lighter text-info text-decoration-underline">{{ topic.forum }}</span></a>
-                                    {% endif %}
                                 </div>
                                 <div class="col-12 post-content">
                                     <div id="showmoretopicsarea{{ topic.pk }}">


### PR DESCRIPTION
## Description

🎸 Afficher le forum de publication de message, à la suite des infos du poster

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Passage du parametre `forum` à l'include `poster`


### Captures d'écran (optionnel)

Avec mention du forum

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/dcdd0eed-3d65-45ed-ac52-a5e4ab9c5643)

Sans mention du forum

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/7994d822-f685-4ca0-93be-447071863232)
