### PR TITLE
feat(tags): rendre les tags clickables

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -411,3 +411,13 @@ class ForumViewTest(TestCase):
         self.user.save()
         response = self.client.get(self.url)
         self.assertContains(response, url)
+
+    def test_filtered_queryset_on_tag(self):
+        tag = faker.word()
+        topic = TopicFactory(forum=self.forum, with_tags=[tag], with_post=True)
+
+        response = self.client.get(
+            reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug}), {"tags": tag}
+        )
+        self.assertContains(response, topic.subject)
+        self.assertNotContains(response, self.topic.subject)

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -26,9 +26,17 @@ PermissionRequiredMixin = get_class("forum_permission.viewmixins", "PermissionRe
 class ForumView(BaseForumView):
     paginate_by = settings.FORUM_TOPICS_NUMBER_PER_PAGE
 
+    def get_tags(self):
+        if not hasattr(self, "tags"):
+            self.tags = self.request.GET.get("tags", "").lower()
+        return self.tags
+
     def get_queryset(self):
         forum = self.get_forum()
         qs = forum.topics.optimized_for_topics_list(self.request.user.id)
+
+        if self.get_tags():
+            qs = qs.filter(tags__slug__in=self.get_tags().split(","))
 
         return qs
 

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -833,6 +833,20 @@ class TopicListViewTest(TestCase):
         response = self.client.get(self.url, **{"HTTP_HX_REQUEST": "true"})
         self.assertTemplateUsed(response, "forum_conversation/topic_list.html")
 
+    def test_clickable_tags(self):
+        tag = Tag.objects.create(name="tag")
+        TopicFactory(with_post=True, forum=self.forum, with_tags=[tag.name])
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            (
+                f'<a href="{self.url}?tags={tag.slug}"><span class="badge badge-xs rounded-pill bg-info-lighter '
+                f'text-info">{ tag.name }</span></a>'
+            ),
+        )
+
 
 class NewsFeedTopicListViewTest(TestCase):
     @classmethod

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,1 +1,4 @@
-{% for tag in tags %}<span class="badge badge-xs rounded-pill bg-info-lighter text-info">{{ tag }}</span>{% endfor %}
+{% load url_add_query %}
+{% for tag in tags %}
+    <a href="{% url_add_query request.get_full_path tags=tag.slug %}"><span class="badge badge-xs rounded-pill bg-info-lighter text-info">{{ tag }}</span></a>
+{% endfor %}


### PR DESCRIPTION
## Description

🎸 Permettre d'activer le filtre des `Topic` en cliquant sur le `Tag` dans la liste
🎸 Ajouter le filtre sur `Tag` dans la vue `ForumView` pour éviter les inconsistences UI, bien que cette page sera revue avec #612 et #619

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

