### PR TITLE
feat: Mise à jour de l'entête

### DIFF
--- a/lacommunaute/templates/partials/header_nav_secondary_items.html
+++ b/lacommunaute/templates/partials/header_nav_secondary_items.html
@@ -22,9 +22,6 @@
            data-matomo-option="documentation_header">{% trans "Documents" %}</a>
     </li>
     <li>
-        <a href="{{ seeker_url }}" class="{% if request.path == seeker_url %}is-active{% endif %}">Mon stage CIP</a>
-    </li>
-    <li>
         <a href="{{ dsp_url }}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="dsp">
             <strong class="mx-2">Diagnostic Parcours IAE</strong>
             <span class="badge badge-base rounded-pill bg-important"><i class="ri-bubble-chart-line  font-weight-medium" aria-hidden="true"></i> Nouveau</span>

--- a/lacommunaute/templates/partials/header_nav_secondary_items.html
+++ b/lacommunaute/templates/partials/header_nav_secondary_items.html
@@ -22,9 +22,8 @@
            data-matomo-option="documentation_header">{% trans "Documents" %}</a>
     </li>
     <li>
-        <a href="{{ dsp_url }}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="dsp">
-            <strong class="mx-2">Diagnostic Parcours IAE</strong>
-            <span class="badge badge-base rounded-pill bg-important"><i class="ri-bubble-chart-line  font-weight-medium" aria-hidden="true"></i> Nouveau</span>
+        <a href="{{ dsp_url }}" class="{% if request.path == dsp_url %}is-active {% endif %}matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="dsp">
+            Diagnostic Parcours IAE
         </a>
     </li>
 </ul>

--- a/lacommunaute/templates/partials/header_nav_secondary_items.html
+++ b/lacommunaute/templates/partials/header_nav_secondary_items.html
@@ -16,7 +16,7 @@
     </li>
     <li>
         <a href="{{ documentation_url }}"
-           class="{% if request.path == documentation_url %}is-active{% endif %}matomo-event"
+           class="{% if request.path == documentation_url %}is-active {% endif %}matomo-event"
            data-matomo-category="engagement"
            data-matomo-action="view"
            data-matomo-option="documentation_header">{% trans "Documents" %}</a>


### PR DESCRIPTION
## Description

🎸 suppression du lien "mon stage CIP". le lien reste accessible dans le footer.
🎸 suppression de la mise en valeur du lien 'diag parcours IAE'
🎸 fix de la classe sur le lien documentation

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🎨 UI
🚧 technique

### Captures d'écran (optionnel)
![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/b2ae473e-c559-47ae-9dc6-e823153b1ebd)
