### PR TITLE
feat: mise à jour de la bannière d'un forum

### DIFF
--- a/lacommunaute/forum/forms.py
+++ b/lacommunaute/forum/forms.py
@@ -29,6 +29,7 @@ class ForumForm(forms.ModelForm):
     description = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 20}), required=False, label="Contenu (markdown autorisé)"
     )
+    image = forms.ImageField(label="Banniere de couverture")
 
     def save(self, commit=True):
         forum = super().save(commit=False)
@@ -39,4 +40,4 @@ class ForumForm(forms.ModelForm):
 
     class Meta:
         model = Forum
-        fields = ["name", "short_description", "description"]
+        fields = ["name", "short_description", "description", "image"]

--- a/lacommunaute/forum/forms.py
+++ b/lacommunaute/forum/forms.py
@@ -29,7 +29,7 @@ class ForumForm(forms.ModelForm):
     description = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 20}), required=False, label="Contenu (markdown autorisé)"
     )
-    image = forms.ImageField(label="Banniere de couverture")
+    image = forms.ImageField(required=False, label="Banniere de couverture")
 
     def save(self, commit=True):
         forum = super().save(commit=False)

--- a/lacommunaute/forum/tests/test_forum_updateview.py
+++ b/lacommunaute/forum/tests/test_forum_updateview.py
@@ -1,9 +1,28 @@
+from io import BytesIO
+
 import pytest  # noqa
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
+from faker import Faker
+from PIL import Image
 from pytest_django.asserts import assertContains
 
-from lacommunaute.users.factories import UserFactory
 from lacommunaute.forum.factories import ForumFactory
+from lacommunaute.users.factories import UserFactory
+
+
+@pytest.fixture
+def fake_image():
+    fake = Faker()
+    image_name = fake.pystr(min_chars=30, max_chars=40, prefix="pytest_", suffix=".png")
+
+    image = Image.new("RGB", (100, 100))
+    image_file = BytesIO()
+    image.save(image_file, format="JPEG")
+    image_file.seek(0)
+    uploaded_image = SimpleUploadedFile(image_name, image_file.read(), content_type="image/jpeg")
+
+    yield uploaded_image
 
 
 def test_user_access(client, db):

--- a/lacommunaute/forum/tests/tests_forms.py
+++ b/lacommunaute/forum/tests/tests_forms.py
@@ -43,3 +43,7 @@ def test_form_field():
     form = ForumForm()
     assert form.Meta.model == Forum
     assert form.Meta.fields == ["name", "short_description", "description", "image"]
+    assert form.fields["name"].required
+    assert form.fields["short_description"].required
+    assert not form.fields["description"].required
+    assert not form.fields["image"].required

--- a/lacommunaute/forum/tests/tests_forms.py
+++ b/lacommunaute/forum/tests/tests_forms.py
@@ -37,3 +37,9 @@ def test_saved_forum_description(db):
         "<p>Text</p>\n\n<div><iframe src='xxx'></iframe></div>\n\n"
         "<p>text</p>\n\n<div><iframe src='yyy'></iframe></div>\n\n<p>bye</p>"
     )
+
+
+def test_form_field():
+    form = ForumForm()
+    assert form.Meta.model == Forum
+    assert form.Meta.fields == ["name", "short_description", "description", "image"]

--- a/lacommunaute/templates/forum/partials/forum_form.html
+++ b/lacommunaute/templates/forum/partials/forum_form.html
@@ -9,6 +9,7 @@
     {% include "partials/form_field.html" with field=form.name %}
     {% include "partials/form_field.html" with field=form.short_description %}
     {% include "partials/form_field.html" with field=form.description %}
+    {% include "partials/form_field.html" with field=form.image %}
     <hr class="mb-5">
     <div class="form-actions form-row">
         <div class="form-group col-auto">


### PR DESCRIPTION
## Description

🎸 Permettre la mise à jour de la bannière d'un forum depuis le formulaire de creation et de mise à jour

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).


### Points d'attention

🦺 Les fichiers générés par les tests ne sont pas supprimés du bucket minio


### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/17a54110-7a2a-4287-9298-515f860773a1)
