### PR TITLE
fix: Mise à jour de l'action `release-please`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: python


### PR DESCRIPTION
## Description

🎸 Mise à jour de l'action `release-please`

## Type de changement

🚧 technique

### Points d'attention

🦺 google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead

