### PR TITLE
fix: Diag parcours IAE - masquer la carte des fiches pratiques liées lorsqu'elle est vide

### DIFF
--- a/lacommunaute/surveys/tests/__snapshots__/test_views.ambr
+++ b/lacommunaute/surveys/tests/__snapshots__/test_views.ambr
@@ -256,15 +256,7 @@
                       
                   </div>
               </div>
-              <div class="s-section__row row">
-                  <div class="s-section__col col-lg-8 col-12 c-box mb-5">
-                      <strong>Articles associés</strong>
-  <ul>
-      
-  </ul>
-  
-                  </div>
-              </div>
+              
               <div class="s-section__row row">
                   <div class="s-section__col col-12 col-lg-8 c-box mb-5">
                       <iframe data-tally-src="https://tally.so/embed/w8QqMz?alignLeft=1&amp;hideTitle=1&amp;transparentBackground=1&amp;dynamicHeight=1" frameborder="0" height="262" loading="lazy" marginheight="0" marginwidth="0" title="DSP Feedback" width="100%"></iframe>
@@ -539,15 +531,7 @@
                       
                   </div>
               </div>
-              <div class="s-section__row row">
-                  <div class="s-section__col col-lg-8 col-12 c-box mb-5">
-                      <strong>Articles associés</strong>
-  <ul>
-      
-  </ul>
-  
-                  </div>
-              </div>
+              
               <div class="s-section__row row">
                   <div class="s-section__col col-12 col-lg-8 c-box mb-5">
                       <iframe data-tally-src="https://tally.so/embed/w8QqMz?alignLeft=1&amp;hideTitle=1&amp;transparentBackground=1&amp;dynamicHeight=1" frameborder="0" height="262" loading="lazy" marginheight="0" marginwidth="0" title="DSP Feedback" width="100%"></iframe>
@@ -774,15 +758,7 @@
                       
                   </div>
               </div>
-              <div class="s-section__row row">
-                  <div class="s-section__col col-lg-8 col-12 c-box mb-5">
-                      <strong>Articles associés</strong>
-  <ul>
-      
-  </ul>
-  
-                  </div>
-              </div>
+              
               <div class="s-section__row row">
                   <div class="s-section__col col-12 col-lg-8 c-box mb-5">
                       <iframe data-tally-src="https://tally.so/embed/w8QqMz?alignLeft=1&amp;hideTitle=1&amp;transparentBackground=1&amp;dynamicHeight=1" frameborder="0" height="262" loading="lazy" marginheight="0" marginwidth="0" title="DSP Feedback" width="100%"></iframe>
@@ -1052,15 +1028,7 @@
                       
                   </div>
               </div>
-              <div class="s-section__row row">
-                  <div class="s-section__col col-lg-8 col-12 c-box mb-5">
-                      <strong>Articles associés</strong>
-  <ul>
-      
-  </ul>
-  
-                  </div>
-              </div>
+              
               <div class="s-section__row row">
                   <div class="s-section__col col-12 col-lg-8 c-box mb-5">
                       <iframe data-tally-src="https://tally.so/embed/w8QqMz?alignLeft=1&amp;hideTitle=1&amp;transparentBackground=1&amp;dynamicHeight=1" frameborder="0" height="262" loading="lazy" marginheight="0" marginwidth="0" title="DSP Feedback" width="100%"></iframe>

--- a/lacommunaute/templates/surveys/dsp_detail.html
+++ b/lacommunaute/templates/surveys/dsp_detail.html
@@ -51,11 +51,13 @@
                     {% endfor %}
                 </div>
             </div>
-            <div class="s-section__row row">
-                <div class="s-section__col col-lg-8 col-12 c-box mb-5">
-                    {% include "surveys/partials/related_forums.html" with related_forums=related_forums only %}
+            {% if related_forums %}
+                <div class="s-section__row row">
+                    <div class="s-section__col col-lg-8 col-12 c-box mb-5">
+                        {% include "surveys/partials/related_forums.html" with related_forums=related_forums only %}
+                    </div>
                 </div>
-            </div>
+            {% endif %}
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-lg-8 c-box mb-5">
                     <iframe data-tally-src="https://tally.so/embed/w8QqMz?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1"

--- a/lacommunaute/templates/surveys/dsp_form.html
+++ b/lacommunaute/templates/surveys/dsp_form.html
@@ -76,13 +76,15 @@
                     </div>
                 </div>
             {% endif %}
-            <div class="s-section__row row">
-                <div class="s-section__col col-lg-8 col-12">
-                    <div class="c-box mb-5">
-                        {% include "surveys/partials/related_forums.html" with related_forums=related_forums only %}
+            {% if related_forums %}
+                <div class="s-section__row row">
+                    <div class="s-section__col col-lg-8 col-12">
+                        <div class="c-box mb-5">
+                            {% include "surveys/partials/related_forums.html" with related_forums=related_forums only %}
+                        </div>
                     </div>
                 </div>
-            </div>
+            {% endif %}
         </div>
     </section>
 {% endblock content %}


### PR DESCRIPTION
## Description

🎸 masquer la carte des fiches pratiques liées lorsqu'elle est vide

## Type de changement

🎨 changement d'UI

