### PR TITLE
fix(quality): formatage des balises `script` dans le gabarit `base.html`

### DIFF
--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -25,6 +25,4 @@
 <div id="postinfeedarea{{ topic.pk }}">
     {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form inline=1 %}
 </div>
-<script>
-    document.getElementById(`collapseButtonPost{{topic.pk}}`).setAttribute('aria-expanded', 'false');
-</script>
+<script>document.getElementById(`collapseButtonPost{{topic.pk}}`).setAttribute('aria-expanded', 'false');</script>

--- a/lacommunaute/templates/forum_conversation/partials/post_feed.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_feed.html
@@ -25,4 +25,8 @@
 <div id="postinfeedarea{{ topic.pk }}">
     {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form inline=1 %}
 </div>
-<script>document.getElementById(`collapseButtonPost{{topic.pk}}`).setAttribute('aria-expanded', 'false');</script>
+{# djlint:off #}
+<script>
+    document.getElementById(`collapseButtonPost{{topic.pk}}`).setAttribute('aria-expanded', 'false');
+</script>
+{# djlint:on #}

--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -109,18 +109,15 @@
         {% block js %}
             {% import_static_JS_theme_inclusion %}
             <script src="{% static 'machina/build/js/machina.min.js' %}" type="text/javascript" charset="utf-8"></script>
-            {# djlint: off #}
             <script type="text/javascript" nonce="{{ request.csp_nonce }}">
                 $(function() {
                     machina.init();
                     {% block onbodyload %}{% endblock onbodyload %}
                 });
-</script>
-            {# djlint: on #}
+            </script>
         {% endblock %}
         {% block extra_js %}
             <script src="{% static "vendor/tarteaucitron.js-1.11.0/tarteaucitron.js" %}"></script>
-            {# djlint: off #}
             <script nonce="{{ request.csp_nonce }}">
                 // Tarteaucitron's language is set according to the browser configuration
                 // but a lot of users don't know how to change it.
@@ -180,8 +177,7 @@
                     tarteaucitron.user.matomoHost = '{{ MATOMO_BASE_URL }}';
                     (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
                 {% endif %}
-</script>
-            {# djlint: on #}
+            </script>
             {% if MATOMO_BASE_URL %}
                 <script type="text/javascript" src="{% static 'javascripts/matomo.js' %}" defer></script>
             {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,10 @@ export_dev = { shell = "poetry export --with dev --output requirements/dev.txt" 
 line_length = 119
 
 [tool.ruff]
-ignore = []
 line-length = 119
+
+[tool.ruff.lint]
+ignore = []
 # see prefixes in https://beta.ruff.rs/docs/rules/
 select = [
     "F",  # pyflakes
@@ -72,7 +74,7 @@ select = [
     "I",  # isort
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["lacommunaute"]
 lines-after-imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,4 +84,4 @@ profile="django"
 ignore="T002,T003,T027,H006,H023,D018"
 max_attribute_length=200
 format_css = true
-format_js = true
+format_js = false


### PR DESCRIPTION
## Description

🎸 correction du formatage des balises scripts dans le gabarit `base.html`, en lien avec [l'issue 824 djlint](https://github.com/djlint/djLint/issues/824) : set `tool.djlint.format_js` à `false

🎸 mise à jour des paramètres des linters dans `pyproject.toml` pour résoudre les warning de l'issue #648 

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

