### PR TITLE
feat(forum_conversation): remettre les annonces dans la liste des messages par défaut

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -10,7 +10,6 @@ from lacommunaute.forum.factories import CategoryForumFactory, ForumFactory
 from lacommunaute.forum.views import ForumView
 from lacommunaute.forum_conversation.factories import CertifiedPostFactory, PostFactory, TopicFactory
 from lacommunaute.forum_conversation.forms import PostForm
-from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.utils.testing import parse_response_to_soup
 
@@ -31,10 +30,6 @@ class ForumViewQuerysetTest(TestCase):
         cls.view.kwargs = {"pk": cls.forum.pk}
         cls.view.request = RequestFactory().get("/")
         cls.view.request.user = cls.user
-
-    def test_excluded_announces_topics(self):
-        TopicFactory(forum=self.forum, poster=self.user, type=Topic.TOPIC_ANNOUNCE)
-        self.assertFalse(self.view.get_queryset())
 
     def test_exclude_not_approved_posts(self):
         TopicFactory(forum=self.forum, poster=self.user, approved=False)
@@ -180,7 +175,7 @@ class ForumViewTest(TestCase):
 
         TopicFactory.create_batch(20, with_post=True)
         self.client.force_login(self.user)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(22):
             self.client.get(self.url)
 
     def test_certified_post_display(self):

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -13,7 +13,6 @@ from lacommunaute.forum.enums import Kind as ForumKind
 from lacommunaute.forum.forms import ForumForm
 from lacommunaute.forum.models import Forum
 from lacommunaute.forum_conversation.forms import PostForm
-from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_upvote.models import UpVote
 from lacommunaute.utils.perms import add_public_perms_on_forum
 
@@ -59,17 +58,6 @@ class ForumView(BaseForumView):
         )
         context["loadmoretopic_suffix"] = "topicsinforum"
         context["form"] = PostForm(forum=forum, user=self.request.user)
-        context["announces"] = list(
-            self.get_forum()
-            .topics.select_related(
-                "poster",
-                "poster__forum_profile",
-                "first_post",
-                "first_post__poster",
-                "forum",
-            )
-            .filter(type=Topic.TOPIC_ANNOUNCE)
-        )
         if forum.parent and forum.is_in_documentation_area:
             context["forums"] = forum.get_siblings(include_self=True)
         return context

--- a/lacommunaute/forum_conversation/admin.py
+++ b/lacommunaute/forum_conversation/admin.py
@@ -22,6 +22,7 @@ class TopicAdmin(BaseTopicAdmin):
     inlines = [
         PostInline,
     ]
+    list_filter = BaseTopicAdmin.list_filter + ("type",)
 
 
 class CertifiedPostAdmin(admin.ModelAdmin):

--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -25,7 +25,7 @@ class TopicQuerySet(models.QuerySet):
     def optimized_for_topics_list(self, user_id):
         return (
             self.exclude(approved=False)
-            .filter(type__in=[Topic.TOPIC_POST, Topic.TOPIC_STICKY])
+            .filter(type__in=[Topic.TOPIC_POST, Topic.TOPIC_STICKY, Topic.TOPIC_ANNOUNCE])
             .select_related(
                 "forum",
                 "poster",

--- a/lacommunaute/forum_conversation/tests/tests_models.py
+++ b/lacommunaute/forum_conversation/tests/tests_models.py
@@ -57,12 +57,14 @@ class TopicManagerTest(TestCase):
         annonce = TopicFactory(type=Topic.TOPIC_ANNOUNCE)
         sticky = TopicFactory(type=Topic.TOPIC_STICKY)
         topic = TopicFactory(type=Topic.TOPIC_POST)
+        unapproved_topic = TopicFactory(type=Topic.TOPIC_POST, approved=False)
 
         qs = Topic.objects.optimized_for_topics_list(1)
 
-        self.assertNotIn(annonce, qs)
+        self.assertIn(annonce, qs)
         self.assertIn(sticky, qs)
         self.assertIn(topic, qs)
+        self.assertNotIn(unapproved_topic, qs)
 
     def test_optimized_for_topics_list_order(self):
         topic1 = TopicFactory(with_post=True)

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -163,11 +163,6 @@
                             <li class="nav-item" role="presentation">
                                 <a class="nav-link active" id="topics-tab" data-bs-toggle="tab" href="#topics" role="tab" aria-controls="topics" aria-selected="true">Sujets</a>
                             </li>
-                            {% if announces %}
-                                <li class="nav-item" role="presentation">
-                                    <a class="nav-link" id="announces-tab" data-bs-toggle="tab" href="#announces" role="tab" aria-controls="announces" aria-selected="false">Annonces</a>
-                                </li>
-                            {% endif %}
                         </ul>
                         <div class="tab-content topiclist">
                             <div class="tab-pane fade show active" id="topics" role="tabpanel" aria-labelledby="topics-tab">
@@ -176,14 +171,6 @@
                                     <!-- note vincentporte : to be optimized -->
                                 {% endwith %}
                             </div>
-                            {% if announces %}
-                                <div class="tab-pane fade" id="announces" role="tabpanel" aria-labelledby="announces-tab">
-                                    {% with topics=announces hide_if_empty=True unread_topics=unread_topics loadmoretopic_url=None %}
-                                        {% include "forum_conversation/topic_list.html" %}
-                                        <!-- note vincentporte : to be optimized -->
-                                    {% endwith %}
-                                </div>
-                            {% endif %}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Description

🎸 Afficher les annonces dans le fil des messages
🎸 Supprimer l'onglet annonce dans la vue d'un `Forum`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🎨 changement d'UI

### Captures d'écran (optionnel)

<img width="1309" alt="Screenshot 2024-06-06 at 17 38 13" src="https://github.com/gip-inclusion/itou-communaute-django/assets/10801930/cca2e93c-1e4e-4e47-9cd5-bfb764ed301b">