### PR TITLE
fix(forum_conversation): page 1 forcée dans les liens tags

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -950,7 +950,8 @@ class TopicListViewTest(TestCase):
         self.assertContains(
             response,
             (
-                f'<a href="{self.url}?tags={tag.slug}"><span class="badge badge-xs rounded-pill bg-info-lighter '
+                f'<a href="{self.url}?tags={tag.slug}&amp;page=1">'
+                '<span class="badge badge-xs rounded-pill bg-info-lighter '
                 f'text-info">{ tag.name }</span></a>'
             ),
         )

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,4 +1,4 @@
 {% load url_add_query %}
 {% for tag in tags %}
-    <a href="{% url_add_query request.get_full_path tags=tag.slug %}"><span class="badge badge-xs rounded-pill bg-info-lighter text-info">{{ tag }}</span></a>
+    <a href="{% url_add_query request.get_full_path tags=tag.slug page=1 %}"><span class="badge badge-xs rounded-pill bg-info-lighter text-info">{{ tag }}</span></a>
 {% endfor %}


### PR DESCRIPTION
## Description

🎸 forcer le paramètre page=1 sur les liens de filtrage sur tag dans la liste des topics, en utilisant url_add_query [templatetag](https://github.com/gip-inclusion/itou-communaute-django/blob/5c74c5601c134f0f8adaa07c1f758dde3fa1b887/lacommunaute/utils/templatetags/url_add_query.py#L11) dans topic_tags.html [ref](https://github.com/gip-inclusion/itou-communaute-django/blob/5c74c5601c134f0f8adaa07c1f758dde3fa1b887/lacommunaute/templates/forum_conversation/partials/topic_tags.html#L3)

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Captures d'écran (optionnel)

Réplication du problème :

<img width="551" alt="Screenshot 2024-06-11 at 11 16 17" src="https://github.com/gip-inclusion/itou-communaute-django/assets/10801930/66b71760-fccd-4ab1-9819-f655e30f720e">

Avec le fix :

<img width="1345" alt="Screenshot 2024-06-11 at 11 05 27" src="https://github.com/gip-inclusion/itou-communaute-django/assets/10801930/b710e265-42e8-4ca5-8023-a65ca840e60c">