### PR TITLE
chore(docker): Meilleur redemarrage des conteneurs docker en fin d'import de base de données

### DIFF
--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -32,7 +32,7 @@ echo "restoring db"
 docker exec -ti commu_postgres pg_restore -U $POSTGRESQL_ADDON_USER --dbname=$POSTGRESQL_ADDON_DB --format=c --clean --no-owner --verbose /backups/$DB_BACKUP_NAME
 
 echo "restarting db"
-docker-compose down; docker-compose up postgres -d
+docker-compose down postgres; docker-compose up postgres -d
 
 echo "faking password"
 python manage.py set_fake_passwords


### PR DESCRIPTION
## Description

🎸 L'ajout de `minio` dans la stack `docker` a fait apparaitre un effet indesirable lors de l'import de db.
1. en fin d'import, tous les conteneurs étaient éteints
2. puis seul le conteneur `postgres` était relancés
La modification consiste à n'eteindre que le conteneur `postgres` pour le relancer ensuite, et laisser en fonctionnement `minio` et éventuellement `django`

## Type de changement

🚧 technique

