### PR TITLE
fix(stats): derniere date collectée des stats matomo

### DIFF
--- a/lacommunaute/forum_stats/management/commands/collect_matomo_stats.py
+++ b/lacommunaute/forum_stats/management/commands/collect_matomo_stats.py
@@ -7,6 +7,18 @@ from lacommunaute.forum_stats.models import Stat
 from lacommunaute.utils.matomo import collect_stats_from_matomo_api
 
 
+matomo_stats_names = [
+    "nb_uniq_visitors",
+    "nb_uniq_visitors_returning",
+    "nb_uniq_active_visitors",
+    "nb_uniq_engaged_visitors",
+]
+
+
+def get_initial_from_date(period):
+    return Stat.objects.filter(period=period, name__in=matomo_stats_names).order_by("-date").first()
+
+
 class Command(BaseCommand):
     help = "Collecter les stats matomo, jusqu'à la veille de l'execution"
 
@@ -16,7 +28,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         period = options["period"]
 
-        from_date = Stat.objects.filter(period=period).order_by("-date").first()
+        from_date = get_initial_from_date(period)
 
         if from_date:
             if period == "day":

--- a/lacommunaute/forum_stats/tests/tests_management_commands.py
+++ b/lacommunaute/forum_stats/tests/tests_management_commands.py
@@ -1,5 +1,5 @@
 import pytest  # noqa
-
+from lacommunaute.forum_stats.management.commands.collect_matomo_stats import get_initial_from_date
 from django.core.management import call_command
 from lacommunaute.surveys.factories import DSPFactory
 from lacommunaute.forum_stats.factories import StatFactory
@@ -11,3 +11,18 @@ def test_collect_django_stats(db, capsys):
     call_command("collect_django_stats")
     captured = capsys.readouterr()
     assert captured.out.strip() == "Collecting DSP stats from 2024-05-18 to yesterday: 1 new stats\nThat's all, folks!"
+
+
+@pytest.mark.parametrize(
+    "name", ["nb_uniq_visitors", "nb_uniq_visitors_returning", "nb_uniq_active_visitors", "nb_uniq_engaged_visitors"]
+)
+def test_get_initial_from_date_in_collect_matomo_stats(db, name):
+    # desired datas for sorting test
+    StatFactory(period="day", name=name, date="2024-05-17")
+    stat = StatFactory(period="day", name=name, date="2024-05-18")
+
+    # undesired datas
+    StatFactory(period="xxx", name=name, date="2024-05-19")
+    StatFactory(period="day", name="unexpected_name", date="2024-05-20")
+
+    assert get_initial_from_date("day") == stat


### PR DESCRIPTION
## Description

🎸 Rechercher la derniere date uniquement sur les stats matomo

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 stats matomo : `["nb_uniq_visitors", "nb_uniq_visitors_returning", "nb_uniq_active_visitors", "nb_uniq_engaged_visitors"]`


