### PR TITLE
chore: suppression du tag manager matomo

### DIFF
--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -36,20 +36,6 @@
             {% if not debug %}
                 <script src="https://js.sentry-cdn.com/315adbc1472b4c5f875aa426db1fe8f2.min.js" crossorigin="anonymous"></script>
             {% endif %}
-            <!-- Matomo Tag Manager -->
-            <script nonce="{{ request.csp_nonce }}">
-                var _mtm = window._mtm = window._mtm || [];
-                _mtm.push({
-                    'mtm.startTime': (new Date().getTime()),
-                    'event': 'mtm.Start'
-                });
-                var d = document,
-                    g = d.createElement('script'),
-                    s = d.getElementsByTagName('script')[0];
-                g.async = true;
-                g.src = 'https://matomo.inclusion.beta.gouv.fr/js/container_GTln5jDH.js';
-                s.parentNode.insertBefore(g, s);
-            </script>
         {% endblock head %}
         {% block extra_head %}{% endblock %}
         {% block css %}


### PR DESCRIPTION
## Description

🎸 suppression du tag manager matomo non exploité dans l'extraction des statistiques

## Type de changement

🚧 technique

