### PR TITLE
feat(stats): page hebdo partenaires fiches pratiques

### DIFF
--- a/lacommunaute/forum/factories.py
+++ b/lacommunaute/forum/factories.py
@@ -54,3 +54,9 @@ class ForumRatingFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = ForumRating
+
+    @factory.post_generation
+    def set_created(self, create, extracted, **kwargs):
+        if extracted:
+            self.created = extracted
+            self.save()

--- a/lacommunaute/forum/models.py
+++ b/lacommunaute/forum/models.py
@@ -77,6 +77,9 @@ class Forum(AbstractForum):
     def get_session_rating(self, session_key):
         return getattr(ForumRating.objects.filter(forum=self, session_id=session_key).first(), "rating", None)
 
+    def get_average_rating(self):
+        return ForumRating.objects.filter(forum=self).aggregate(models.Avg("rating"))["rating__avg"]
+
 
 class ForumRating(DatedModel):
     session_id = models.CharField(max_length=40)

--- a/lacommunaute/forum/tests/tests_model.py
+++ b/lacommunaute/forum/tests/tests_model.py
@@ -117,3 +117,10 @@ class ForumModelTest(TestCase):
 
         ForumRatingFactory(forum=forum, session_id=forum_rating.session_id, rating=forum_rating.rating + 1)
         self.assertEqual(forum.get_session_rating(forum_rating.session_id), forum_rating.rating + 1)
+
+    def test_get_average_rating(self):
+        forum = ForumFactory()
+        ForumRatingFactory(forum=forum, rating=1)
+        ForumRatingFactory(forum=forum, rating=5)
+
+        self.assertEqual(forum.get_average_rating(), 3)

--- a/lacommunaute/stats/factories.py
+++ b/lacommunaute/stats/factories.py
@@ -36,3 +36,6 @@ class ForumStatFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = ForumStat
+
+    class Params:
+        for_snapshot = factory.Trait(period="week", date=datetime.date(2024, 5, 20))

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -11,6 +11,102 @@
           </nav>
   '''
 # ---
+# name: TestForumStatWeekArchiveView.test_header_and_breadcrumb[breadcrumb]
+  '''
+  <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+  '''
+# ---
+# name: TestForumStatWeekArchiveView.test_header_and_breadcrumb[title-01]
+  '''
+  <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">
+                          <strong>Partenariat Academie France Travail x La communauté de l'inclusion</strong>
+                          <br/>
+                          Statistiques de la semaine du 20 mai 2024 au 26 mai 2024
+                      </h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: TestForumStatWeekArchiveView.test_most_rated_forums[most_rated_forums]
+  '''
+  <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <h2>Les 1 fiches pratiques les plus notées sur la période</h2>
+                          <table class="table">
+                              <thead>
+                                  <tr>
+                                      <th scope="col">Fiche Pratique</th>
+                                      <th scope="col">Nouvelles otations sur la période</th>
+                                      <th scope="col">Evaluation globale</th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">Forum A</th>
+                                          <td>2</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestForumStatWeekArchiveView.test_most_viewed_forums[most_viewed_forums]
+  '''
+  <div class="s-section__row row" id="most_viewed">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <h2>Les 2 fiches pratiques les plus lues sur la période</h2>
+                          <table class="table">
+                              <thead>
+                                  <tr>
+                                      <th scope="col">Fiche Pratique</th>
+                                      <th scope="col">Visiteurs uniques</th>
+                                      <th scope="col">Visiteurs uniques entrants</th>
+                                      <th scope="col">Temps de lecture total</th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">Forum B</th>
+                                          <td>17</td>
+                                          <td>5</td>
+                                          <td>1978 secondes</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">Forum A</th>
+                                          <td>10</td>
+                                          <td>8</td>
+                                          <td>1000 secondes</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
 # name: TestMonthlyVisitorsView.test_navigation[breadcrumb]
   '''
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -50,8 +50,8 @@
                               <thead>
                                   <tr>
                                       <th scope="col">Fiche Pratique</th>
-                                      <th scope="col">Nouvelles otations sur la période</th>
-                                      <th scope="col">Evaluation globale</th>
+                                      <th scope="col">Nombres de notations de la semaine</th>
+                                      <th scope="col">Notation moyenne totale</th>
                                   </tr>
                               </thead>
                               <tbody>

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -9,10 +9,11 @@ from django.utils.dateformat import format
 from django.utils.timezone import localdate
 from faker import Faker
 from machina.core.loading import get_class
-from pytest_django.asserts import assertContains
+from pytest_django.asserts import assertContains, assertNotContains
 
+from lacommunaute.forum.factories import ForumFactory, ForumRatingFactory
 from lacommunaute.stats.enums import Period
-from lacommunaute.stats.factories import StatFactory
+from lacommunaute.stats.factories import ForumStatFactory, StatFactory
 from lacommunaute.surveys.factories import DSPFactory
 from lacommunaute.utils.math import percent
 from lacommunaute.utils.testing import parse_response_to_soup
@@ -243,3 +244,103 @@ class TestDailyDSPView:
         response = client.get(url)
         assert response.status_code == 200
         assert str(parse_response_to_soup(response, selector=".c-breadcrumb")) == snapshot(name="breadcrumb")
+
+
+class TestForumStatWeekArchiveView:
+    def get_url_from_date(self, date):
+        return reverse(
+            "stats:forum_stat_week_archive", kwargs={"year": date.strftime("%Y"), "week": date.strftime("%W")}
+        )
+
+    def test_header_and_breadcrumb(self, client, db, snapshot):
+        response = client.get(self.get_url_from_date(ForumStatFactory(for_snapshot=True).date))
+        assert response.status_code == 200
+        assert str(parse_response_to_soup(response, selector=".s-title-01")) == snapshot(name="title-01")
+        assert str(parse_response_to_soup(response, selector=".c-breadcrumb")) == snapshot(name="breadcrumb")
+
+    def test_navigation(self, client, db):
+        weeks = [date.today() - relativedelta(weeks=i) for i in range(15, 10, -1)]
+        for week in weeks[1:4]:
+            ForumStatFactory(date=week, for_snapshot=True)
+
+        test_cases = [
+            {"test_week": weeks[1], "not_contains": [weeks[0]], "contains": [weeks[2]]},
+            {"test_week": weeks[2], "not_contains": [], "contains": [weeks[1], weeks[3]]},
+            {"test_week": weeks[3], "not_contains": [weeks[4]], "contains": [weeks[2]]},
+        ]
+
+        for test_case in test_cases:
+            response = client.get(self.get_url_from_date(test_case["test_week"]))
+            for week in test_case["not_contains"]:
+                assertNotContains(response, self.get_url_from_date(week))
+            for week in test_case["contains"]:
+                assertContains(response, self.get_url_from_date(week))
+
+        # out of bound
+        for week in [weeks[0], weeks[4]]:
+            response = client.get(self.get_url_from_date(week))
+            assert response.status_code == 404
+
+    def test_most_viewed_forums(self, client, db, snapshot):
+        forums_stats = [
+            ForumStatFactory(for_snapshot=True, visits=10, entry_visits=8, time_spent=1000, forum__name="Forum A"),
+            ForumStatFactory(for_snapshot=True, visits=17, entry_visits=5, time_spent=1978, forum__name="Forum B"),
+        ]
+
+        response = client.get(self.get_url_from_date(forums_stats[0].date))
+        assert response.status_code == 200
+        assert str(
+            parse_response_to_soup(
+                response, selector="#most_viewed", replace_in_href=[fs.forum for fs in forums_stats]
+            )
+        ) == snapshot(name="most_viewed_forums")
+
+    def test_paginated_most_viewed_forums(self, client, db):
+        ForumStatFactory.create_batch(16, for_snapshot=True)
+        response = client.get(reverse("stats:forum_stat_week_archive", kwargs={"year": 2024, "week": 21}))
+        assert response.status_code == 200
+        assert len(response.context_data["forum_stats"]) == 15
+
+    def test_most_rated_forums(self, client, db, snapshot):
+        fs = ForumStatFactory(for_snapshot=True, forum__name="Forum A")
+
+        # rating within range
+        ForumRatingFactory.create_batch(2, rating=5, forum=fs.forum, set_created=fs.date)
+        # rating out of range
+        ForumRatingFactory.create_batch(2, rating=1, forum=fs.forum)
+
+        # undesired forum
+        ForumFactory()
+
+        # undesired rating
+        ForumRatingFactory(rating=4)
+
+        response = client.get(self.get_url_from_date(fs.date))
+        assert response.status_code == 200
+        assert str(parse_response_to_soup(response, selector="#most_rated")) == snapshot(name="most_rated_forums")
+
+    def test_visitors(self, client, db, snapshot):
+        fs = ForumStatFactory(for_snapshot=True)
+
+        # relevant
+        relevant_dates = [
+            fs.date,
+            fs.date + relativedelta(days=6),
+            fs.date + relativedelta(days=6) - relativedelta(days=89),
+        ]
+        visitors = [10, 11, 12]
+        for stat_date, visitor_count in zip(relevant_dates, visitors):
+            StatFactory(date=stat_date, name="nb_uniq_visitors", value=visitor_count)
+
+        # undesired
+        for stat_date in [fs.date + relativedelta(weeks=1), fs.date + relativedelta(days=6) - relativedelta(days=90)]:
+            StatFactory(date=stat_date, name="nb_uniq_visitors", value=99)
+
+        response = client.get(self.get_url_from_date(fs.date))
+        assert response.status_code == 200
+        expected_stats = {
+            "date": ["2024-02-27", "2024-05-20", "2024-05-26"],
+            "nb_uniq_visitors": [12, 10, 11],
+            "nb_uniq_engaged_visitors": [],
+        }
+        assert response.context_data["stats"] == expected_stats

--- a/lacommunaute/stats/urls.py
+++ b/lacommunaute/stats/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from lacommunaute.stats.views import DailyDSPView, MonthlyVisitorsView, StatistiquesPageView
+from lacommunaute.stats.views import DailyDSPView, ForumStatWeekArchiveView, MonthlyVisitorsView, StatistiquesPageView
 
 
 app_name = "stats"
@@ -9,4 +9,5 @@ urlpatterns = [
     path("", StatistiquesPageView.as_view(), name="statistiques"),
     path("monthly-visitors/", MonthlyVisitorsView.as_view(), name="monthly_visitors"),
     path("dsp/", DailyDSPView.as_view(), name="dsp"),
+    path("aft/<int:year>/<int:week>/", ForumStatWeekArchiveView.as_view(), name="forum_stat_week_archive"),
 ]

--- a/lacommunaute/stats/views.py
+++ b/lacommunaute/stats/views.py
@@ -1,14 +1,16 @@
+import datetime
 import logging
 
 from dateutil.relativedelta import relativedelta
-from django.db.models import CharField
+from django.db.models import Avg, CharField, Count, Q
 from django.db.models.functions import Cast
-from django.utils import timezone
 from django.utils.dateformat import format
 from django.utils.timezone import localdate
 from django.views.generic.base import TemplateView
+from django.views.generic.dates import WeekArchiveView
 
-from lacommunaute.stats.models import Stat
+from lacommunaute.forum.models import Forum
+from lacommunaute.stats.models import ForumStat, Stat
 from lacommunaute.surveys.models import DSP
 from lacommunaute.utils.json import extract_values_in_list
 from lacommunaute.utils.math import percent
@@ -119,3 +121,42 @@ class DailyDSPView(BaseDetailStatsView):
     indicator_names = ["dsp"]
     period = "day"
     months = 3
+
+
+class ForumStatWeekArchiveView(WeekArchiveView):
+    template_name = "stats/forum_stat_week_archive.html"
+    date_field = "date"
+    queryset = ForumStat.objects.filter(period="week").select_related("forum")
+    week_format = "%W"
+    make_object_list = True
+    context_object_name = "forum_stats"
+    ordering = ["date", "-visits"]
+    paginate_by = 15
+
+    def get_dates_of_the_week(self):
+        start_date = datetime.date(self.get_year(), 1, 1) + datetime.timedelta(weeks=self.get_week() - 1)
+        return start_date, start_date + datetime.timedelta(days=6)
+
+    def get_most_rated_forums(self, start_date, end_date):
+        return (
+            Forum.objects.annotate(avg_rating=Avg("forumrating__rating"))
+            .filter(avg_rating__isnull=False)
+            .annotate(
+                rating_count=Count(
+                    "forumrating",
+                    filter=Q(
+                        forumrating__created__gte=start_date, forumrating__created__lt=end_date + relativedelta(days=1)
+                    ),
+                )
+            )
+            .filter(rating_count__gt=1)
+            .order_by("-rating_count", "avg_rating", "id")
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        start_date, end_date = self.get_dates_of_the_week()
+        context["end_date"] = end_date
+        context["stats"] = get_daily_visits_stats(from_date=end_date - relativedelta(days=89), to_date=end_date)
+        context["rated_forums"] = self.get_most_rated_forums(start_date, end_date)
+        return context

--- a/lacommunaute/templates/stats/forum_stat_week_archive.html
+++ b/lacommunaute/templates/stats/forum_stat_week_archive.html
@@ -84,8 +84,8 @@
                             <thead>
                                 <tr>
                                     <th scope="col">Fiche Pratique</th>
-                                    <th scope="col">Nouvelles otations sur la période</th>
-                                    <th scope="col">Evaluation globale</th>
+                                    <th scope="col">Nombres de notations de la semaine</th>
+                                    <th scope="col">Notation moyenne totale</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/lacommunaute/templates/stats/forum_stat_week_archive.html
+++ b/lacommunaute/templates/stats/forum_stat_week_archive.html
@@ -1,0 +1,188 @@
+{% extends "layouts/base.html" %}
+{% load str_filters %}
+{% load js_filters %}
+{% load static %}
+{% load i18n %}
+{% block title %}Statistiques hebdomadaires{{ block.super }}{% endblock %}
+{% block body_class %}p-statistiques{{ block.super }}{% endblock %}
+{% block breadcrumb %}
+    <div class="container">
+        <nav class="c-breadcrumb" aria-label="Fil d'ariane">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item">{% trans "Back to" %}</li>
+                <li class="breadcrumb-item">
+                    <a href="{% url 'stats:statistiques' %}">Statistiques</a>
+                </li>
+            </ol>
+        </nav>
+    </div>
+{% endblock %}
+{% block content %}
+    <section class="s-title-01 mt-lg-5">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1">
+                        <strong>Partenariat Academie France Travail x La communauté de l'inclusion</strong>
+                        <br>
+                        Statistiques de la semaine du {{ week|date:"j F Y" }} au {{ end_date|date:"j F Y" }}
+                    </h1>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    <div class="c-box mb-3 mb-md-5">
+                        <h2>Trafic global sur la période</h2>
+                        <canvas id="statChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row" id="most_viewed">
+                <div class="s-section__col col-12">
+                    <div class="c-box mb-3 mb-md-5">
+                        <h2>Les {{ object_list|length }} fiches pratiques les plus lues sur la période</h2>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Fiche Pratique</th>
+                                    <th scope="col">Visiteurs uniques</th>
+                                    <th scope="col">Visiteurs uniques entrants</th>
+                                    <th scope="col">Temps de lecture total</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for item in object_list %}
+                                    <tr>
+                                        <th scope="row">{{ item.forum.name }}</th>
+                                        <td>{{ item.visits }}</td>
+                                        <td>{{ item.entry_visits }}</td>
+                                        <td>{{ item.time_spent }} secondes</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row" id="most_rated">
+                <div class="s-section__col col-12">
+                    <div class="c-box mb-3 mb-md-5">
+                        <h2>Les {{ rated_forums|length }} fiches pratiques les plus notées sur la période</h2>
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Fiche Pratique</th>
+                                    <th scope="col">Nouvelles otations sur la période</th>
+                                    <th scope="col">Evaluation globale</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for forum in rated_forums %}
+                                    <tr>
+                                        <th scope="row">{{ forum.name }}</th>
+                                        <td>{{ forum.rating_count }}</td>
+                                        <td>{{ forum.avg_rating|floatformat:2 }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    <div class="mb-3 mb-md-5">
+                        {% if previous_week %}
+                            <a href="{% url 'stats:forum_stat_week_archive' previous_week|date:"Y" previous_week|date:"W" %}">semaine du {{ previous_week|date:"j F Y" }}</a>
+                        {% endif %}
+                        {% if previous_week and next_week %}|{% endif %}
+                        {% if next_week %}
+                            <a href="{% url 'stats:forum_stat_week_archive' next_week|date:"Y" next_week|date:"W" %}">semaine du {{ next_week|date:"j F Y" }}</a>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+{% block extra_js %}
+    {{ block.super }}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.0.1"></script>
+    {# djlint: off #}
+    <script nonce="{{ request.csp_nonce }}">
+        const impact_stats = document.getElementById('impactChart');
+        new Chart(impact_stats, {
+            type: 'bar',
+            data: {
+                labels: {{ impact.date | js }},
+                datasets: [
+                    {
+                        label: 'Professionnels ayant acquis de nouvelles connaissances (estimation)',
+                        data: {{ impact.nb_uniq_visitors_returning | js }},
+                        borderWidth: 2,
+                        borderRadius: 20,
+                        borderSkipped: false,
+                        borderColor: 'rgba(54, 162, 235)',
+                        backgroundColor: 'rgba(154, 208, 245)',
+                    },
+                ]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                x: {
+                    stacked: true,
+                },
+                y: {
+                    stacked: true
+                }
+                }
+            }
+        });
+</script>
+<script nonce="{{ request.csp_nonce }}">
+    const ctx_stats = document.getElementById('statChart');
+    new Chart(ctx_stats, {
+        type: 'line',
+        data: {
+            labels: {{ stats.date | js }},
+            datasets: [
+                {
+                    label: 'Utilisateurs uniques',
+                    data: {{ stats.nb_uniq_visitors | js }},
+                    borderColor: 'rgba(54, 162, 235)',
+                    backgroundColor: 'rgba(154, 208, 245)',
+                },
+                {
+                    label: 'Utilisateurs engagés',
+                    data: {{ stats.nb_uniq_engaged_visitors | js }},
+                    borderColor: 'rgba(255, 159, 64)',
+                    backgroundColor: 'rgba(255, 207, 159)',
+                },
+            ]
+        },
+        options: {
+            responsive:true,
+            cubicInterpolationMode: 'monotone',
+            tension: 0.4,
+        }
+    });
+</script>
+    {# djlint: on #}
+{% endblock %}


### PR DESCRIPTION
## Description

🎸 Ajout d'une `WeekArchiveView` basée sur le modèle `ForumStat`
🎸 Ajout en contexte des stats de visiteurs à la période consultée
🎸 Ajout de la liste des `Forum` les plus notés (au moins 2 notes) sur la période consultée

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 factorisation de la génération des stats des visiteurs : utilisés dans 2 vues
🦺 pagination vers les semaines existantes, pas d'accès aux semaines futures
🦺 affichage des forums les plus vus, limités à 15

### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/18de6014-0e16-4f2a-b88e-eb41582cb194)
