### PR TITLE
feat(admin): améliorer le filtrage des stats de forum

### DIFF
--- a/lacommunaute/stats/admin.py
+++ b/lacommunaute/stats/admin.py
@@ -1,16 +1,44 @@
+from dateutil.relativedelta import relativedelta
 from django.contrib import admin
 
+from lacommunaute.forum.models import Forum
 from lacommunaute.stats.models import ForumStat, Stat
 
 
+class ForumWithStatsFilter(admin.SimpleListFilter):
+    title = "Forum"
+    parameter_name = "forum"
+
+    def lookups(self, request, model_admin):
+        forums_with_stats = model_admin.model.objects.values_list("forum", flat=True).distinct()
+        return [(forum.pk, forum.name) for forum in Forum.objects.filter(pk__in=forums_with_stats)]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(forum=self.value())
+        return queryset
+
+
+class BaseStatAdmin(admin.ModelAdmin):
+    list_display = ("explicit_period",)
+    list_filter = ("date", "period")
+
+    def explicit_period(self, obj):
+        if obj.period == "month":
+            return f"{obj.date} au {obj.date + relativedelta(months=1) - relativedelta(days=1)}"
+        if obj.period == "week":
+            return f"{obj.date} au {obj.date + relativedelta(days=6)}"
+        return f"{obj.date} (jour unique)"
+
+
 @admin.register(Stat)
-class StatAdmin(admin.ModelAdmin):
-    list_display = ("name", "date", "value", "period")
-    list_filter = ("name", "date", "period")
+class StatAdmin(BaseStatAdmin):
+    list_display = BaseStatAdmin.list_display + ("name", "value")
+    list_filter = BaseStatAdmin.list_filter + ("name",)
 
 
 @admin.register(ForumStat)
-class ForumStatAdmin(admin.ModelAdmin):
-    list_display = ("date", "period", "forum", "visits", "entry_visits", "time_spent")
-    list_filter = ("date", "period", "forum")
+class ForumStatAdmin(BaseStatAdmin):
+    list_display = BaseStatAdmin.list_display + ("forum", "visits", "entry_visits", "time_spent")
+    list_filter = BaseStatAdmin.list_filter + (ForumWithStatsFilter,)
     raw_id_fields = ("forum",)


### PR DESCRIPTION
## Description

🎸 rendre la période de la statistiques plus explicite
🎸 filtrer uniquement sur les forums ayant des stats (actuellement les forums de documentation)

## Type de changement

🎨 changement d'UI / ADMIN
🚧 technique

### Captures d'écran (optionnel)

Admin Stat
![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/8fbb0071-17f3-4056-a46f-ec21413dce14)


Admin ForumStat
![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/c704f115-710a-4fc3-a074-b1240714000c)
