### PR TITLE
feat(home): MVP zone editoriale sur la page d'accueil

### DIFF
--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -58,6 +58,55 @@
             <div class="s-section__row row mt-3 mt-md-5">
                 <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
                     <div class="c-box p-0 h-100">
+                        <div class="p-3 p-lg-4 bg-communaute-light">
+                            <h3 class="m-0">
+                                <i class="ri-dashboard-2-fill ri-lg font-weight-normal" aria-hidden="true"></i>
+                                La boîte à outils des CIP
+                            </h3>
+                        </div>
+                        <div class="px-3 px-lg-4 pt-3 pt-lg-4">
+                            La boîte à outils des CIP est espace dédié rassemblant des outils, des guides pour accompagner les acteurs de l'inclusion dans leur soutien aux personnes éloignées du marché du travail, confrontées à des obstacles multiples et complexes.
+                        </div>
+                        <div class="p-3 p-lg-4">
+                            <a href="{% url 'forum_extension:forum' "la-boîte-à-outils-des-cip" 149 %}"
+                               class="btn btn-outline-primary matomo-event"
+                               data-matomo-category="engagement"
+                               data-matomo-action="view"
+                               data-matomo-option="highlight">
+                                <span>Consulter les fiches de la boîte à outils</span>
+                                <i class="ri-arrow-right-up-line ri-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
+                    <div class="c-box p-0 h-100">
+                        <div class="p-3 p-lg-4 bg-light">
+                            <h3 class="m-0">
+                                <i class="ri-article-line ri-lg font-weight-normal" aria-hidden="true"></i>
+                                Les fiches pratique mises à jour
+                            </h3>
+                        </div>
+                        <div class="px-3 px-lg-4 pt-3 pt-lg-4">
+                            <ul class="list-unstyled mb-lg-5">
+                                {% for forum in forums_category %}
+                                    <li class="mb-3 position-relative">
+                                        <a href="{% url 'forum_extension:forum' forum.slug forum.pk %}" class="matomo-event btn-link stretched-link" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">
+                                            {{ forum.name }}
+                                        </a>
+                                        <small>dans {{ forum.parent.name }}</small>
+                                        {% include "forum_conversation/partials/poster_light.html" with poster=None dated=forum.updated only %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                        <div class="p-3 p-lg-4">
+                            <a href="{{ documentation_url }}" class="btn btn-outline-primary btn-block matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation">{% trans "See all docs" %}</a>
+                        </div>
+                    </div>
+                </div>
+                <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
+                    <div class="c-box p-0 h-100">
                         <div class="p-3 p-lg-4 bg-light">
                             <h3 class="m-0">
                                 <i class="ri-user-line ri-lg font-weight-normal" aria-hidden="true"></i>
@@ -84,31 +133,6 @@
                     </div>
                 </div>
                 <div class="s-section__col col-12 col-md-6 mb-3 mb-md-5">
-                    <div class="c-box p-0 h-100">
-                        <div class="p-3 p-lg-4 bg-light">
-                            <h3 class="m-0">
-                                <i class="ri-article-line ri-lg font-weight-normal" aria-hidden="true"></i>
-                                Les fiches pratique mises à jour
-                            </h3>
-                        </div>
-                        <div class="px-3 px-lg-4 pt-3 pt-lg-4">
-                            <ul class="list-unstyled mb-lg-5">
-                                {% for forum in forums_category %}
-                                    <li class="mb-3 position-relative">
-                                        <a href="{% url 'forum_extension:forum' forum.slug forum.pk %}" class="matomo-event btn-link stretched-link" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">
-                                            [{{ forum.parent.name }}] {{ forum.name }}
-                                        </a>
-                                        {% include "forum_conversation/partials/poster_light.html" with poster=None dated=forum.updated only %}
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
-                        <div class="p-3 p-lg-4">
-                            <a href="{{ documentation_url }}" class="btn btn-outline-primary btn-block matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation">{% trans "See all docs" %}</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="s-section__col col-12 mb-3 mb-md-5">
                     <div class="c-box p-0 h-100">
                         <div class="p-3 p-lg-4 bg-light">
                             <h3 class="m-0">


### PR DESCRIPTION
## Description

🎸 Tester la mise en avant d'une zone éditoriale sur la page d'accueil et suivre le traffic via matomo

## Type de changement

🎨 changement d'UI

### Points d'attention

🦺 code static, projet d'xp avec wagtail si test concluant

### Captures d'écran (optionnel)

![image](https://github.com/gip-inclusion/itou-communaute-django/assets/11419273/acc687c6-e909-474a-ac8e-171f70d60282)
