### PR TITLE
fix(notification): mettre à jour le sent_at pour éviter les notifications duplicates

### DIFF
--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -41,7 +41,7 @@ def send_messages_notifications(delay: NotificationDelay):
             template_id=SIB_NEW_MESSAGES_TEMPLATE,
         )
 
-    notifications.bulk_update(sent_at=timezone.now())
+    notifications.update(sent_at=timezone.now())
 
 
 def add_user_to_list_when_register():

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
+from django.utils import timezone
 
 from config.settings.base import DEFAULT_FROM_EMAIL, NEW_MESSAGES_EMAIL_MAX_PREVIEW, SIB_NEW_MESSAGES_TEMPLATE
 from lacommunaute.forum.models import Forum
@@ -14,12 +15,12 @@ from lacommunaute.notification.utils import collect_new_users_for_onboarding, ge
 def send_messages_notifications(delay: NotificationDelay):
     """Notifications are scheduled in the application and then processed later by this task"""
 
+    notifications = Notification.objects.filter(delay=delay, sent_at__isnull=True, post__isnull=False).select_related(
+        "post", "post__topic", "post__poster"
+    )
+
     def get_grouped_notifications():
-        return (
-            Notification.objects.filter(delay=delay, sent_at__isnull=True, post__isnull=False)
-            .select_related("post", "post__topic", "post__poster")
-            .group_by_recipient()
-        )
+        return notifications.group_by_recipient()
 
     grouped_notifications = get_grouped_notifications()
     for recipient in grouped_notifications.keys():
@@ -39,6 +40,8 @@ def send_messages_notifications(delay: NotificationDelay):
             kind=EmailSentTrackKind.FOLLOWING_REPLIES,
             template_id=SIB_NEW_MESSAGES_TEMPLATE,
         )
+
+    notifications.bulk_update(sent_at=timezone.now())
 
 
 def add_user_to_list_when_register():

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -83,6 +83,9 @@ class SendMessageNotificationsTestCase(TestCase):
             email_sent_track.datas, self.get_expected_email_payload(Notification.objects.filter(id=notification.id))
         )
 
+        self.assertIsNone(Notification.objects.filter(sent_at__isnull=True).first())
+        self.assertEqual(Notification.objects.all().values("sent_at").distinct(), 1)
+
     @respx.mock
     def test_send_messages_notifications_day(self):
         topic = TopicFactory(with_post=True)
@@ -96,6 +99,9 @@ class SendMessageNotificationsTestCase(TestCase):
         self.assertEqual(
             email_sent_track.datas, self.get_expected_email_payload(Notification.objects.filter(id=notification.id))
         )
+
+        self.assertIsNone(Notification.objects.filter(sent_at__isnull=True).first())
+        self.assertEqual(Notification.objects.all().values("sent_at").distinct(), 1)
 
     @respx.mock
     def test_send_messages_notifications_max_messages_preview(self):

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -84,7 +84,7 @@ class SendMessageNotificationsTestCase(TestCase):
         )
 
         self.assertIsNone(Notification.objects.filter(sent_at__isnull=True).first())
-        self.assertEqual(Notification.objects.all().values("sent_at").distinct(), 1)
+        self.assertEqual(Notification.objects.all().values("sent_at").distinct().count(), 1)
 
     @respx.mock
     def test_send_messages_notifications_day(self):
@@ -101,7 +101,7 @@ class SendMessageNotificationsTestCase(TestCase):
         )
 
         self.assertIsNone(Notification.objects.filter(sent_at__isnull=True).first())
-        self.assertEqual(Notification.objects.all().values("sent_at").distinct(), 1)
+        self.assertEqual(Notification.objects.all().values("sent_at").distinct().count(), 1)
 
     @respx.mock
     def test_send_messages_notifications_max_messages_preview(self):
@@ -127,7 +127,7 @@ class SendMessageNotificationsTestCase(TestCase):
 
     @respx.mock
     def test_send_messages_notifications_num_queries(self):
-        expected_queries = 1
+        expected_queries = 2
 
         NotificationFactory(delay=NotificationDelay.ASAP)
 


### PR DESCRIPTION
## Description

🎸 mettre à jour le sent_at pour éviter les notifications duplicates

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
