### PR TITLE
feat(notification): passage des notifications en lues

### DIFF
--- a/lacommunaute/forum_conversation/tests/tests_views_htmx.py
+++ b/lacommunaute/forum_conversation/tests/tests_views_htmx.py
@@ -14,6 +14,7 @@ from lacommunaute.forum_moderation.enums import BlockedPostReason
 from lacommunaute.forum_moderation.factories import BlockedDomainNameFactory, BlockedEmailFactory
 from lacommunaute.forum_moderation.models import BlockedPost
 from lacommunaute.forum_upvote.factories import UpVoteFactory
+from lacommunaute.notification.factories import NotificationFactory
 from lacommunaute.users.factories import UserFactory
 
 
@@ -209,6 +210,18 @@ class PostListViewTest(TestCase):
         CertifiedPostFactory(topic=self.topic, post=post, user=self.user)
         response = self.client.get(self.url)
         self.assertContains(response, "Certifié par la Plateforme de l'Inclusion", status_code=200)
+
+    def test_get_marks_notifications_read(self):
+        self.client.force_login(self.user)
+
+        notification = NotificationFactory(recipient=self.user.email, post=self.topic.first_post)
+        self.assertIsNone(notification.sent_at)
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        notification.refresh_from_db()
+        self.assertEqual(str(notification.created), str(notification.sent_at))
 
 
 class PostFeedCreateViewTest(TestCase):

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -15,6 +15,7 @@ from lacommunaute.forum_conversation.forms import PostForm, TopicForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_conversation.shortcuts import can_certify_post, get_posts_of_a_topic_except_first_one
 from lacommunaute.forum_conversation.view_mixins import FilteredTopicsListViewMixin
+from lacommunaute.notification.models import Notification
 
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,11 @@ class TopicView(views.TopicView):
 
     def get_queryset(self):
         return get_posts_of_a_topic_except_first_one(self.topic, self.request.user)
+
+    def get(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            Notification.objects.mark_topic_posts_read(self.get_topic(), request.user)
+        return super().get(request, *args, **kwargs)
 
 
 class TopicListView(FilteredTopicsListViewMixin, ListView):

--- a/lacommunaute/forum_conversation/views_htmx.py
+++ b/lacommunaute/forum_conversation/views_htmx.py
@@ -7,6 +7,7 @@ from machina.core.loading import get_class
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import CertifiedPost, Post, Topic
 from lacommunaute.forum_conversation.shortcuts import can_certify_post, get_posts_of_a_topic_except_first_one
+from lacommunaute.notification.models import Notification
 
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,8 @@ class PostListView(PermissionRequiredMixin, View):
         topic = self.get_topic()
 
         track_handler.mark_topic_read(topic, request.user)
+        if request.user.is_authenticated:
+            Notification.objects.mark_topic_posts_read(topic, request.user)
 
         return render(
             request,

--- a/lacommunaute/notification/admin.py
+++ b/lacommunaute/notification/admin.py
@@ -27,7 +27,7 @@ class SentNotificationListFilter(admin.SimpleListFilter):
 
 @admin.register(Notification)
 class NotificationAdmin(admin.ModelAdmin):
-    list_display = ("kind", "delay", "created", "sent_at")
+    list_display = ("recipient", "kind", "delay", "created", "sent_at", "post_id")
     list_filter = ("kind", "delay", SentNotificationListFilter)
     raw_id_fields = ("post",)
     search_fields = ("recipient", "post__id", "post__subject")

--- a/lacommunaute/notification/factories.py
+++ b/lacommunaute/notification/factories.py
@@ -1,5 +1,9 @@
+import random
+from datetime import timedelta
+
 import factory
 import factory.django
+from django.utils import timezone
 from faker import Faker
 
 from lacommunaute.notification.enums import EmailSentTrackKind
@@ -28,4 +32,4 @@ class NotificationFactory(factory.django.DjangoModelFactory):
         model = Notification
 
     class Params:
-        is_sent = factory.Trait(sent_at=faker.past_datetime())
+        is_sent = factory.Trait(sent_at=(timezone.now() - timedelta(days=random.randint(0, 90))))

--- a/lacommunaute/notification/tests/tests_models.py
+++ b/lacommunaute/notification/tests/tests_models.py
@@ -1,8 +1,12 @@
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import F
 from django.test import TestCase
 
+from lacommunaute.forum_conversation.factories import TopicFactory
 from lacommunaute.notification.enums import EmailSentTrackKind
 from lacommunaute.notification.factories import NotificationFactory
 from lacommunaute.notification.models import EmailSentTrack, Notification
+from lacommunaute.users.factories import UserFactory
 
 
 class EmailSentTrackModelTest(TestCase):
@@ -31,3 +35,57 @@ class NotificationQuerySetTest(TestCase):
         )
 
         self.assertEqual(result[recipient_b], [notification_b])
+
+    def test_mark_topic_posts_read(self):
+        user = UserFactory()
+        topic = TopicFactory(with_post=True)
+
+        NotificationFactory.create_batch(2, recipient=user.email, post=topic.first_post)
+
+        Notification.objects.mark_topic_posts_read(topic, user)
+
+        self.assertEqual(
+            Notification.objects.filter(
+                sent_at__isnull=False, post=topic.first_post, recipient=user.email, sent_at=F("created")
+            ).count(),
+            2,
+        )
+
+    def test_mark_topic_posts_read_doesnt_impact_old_notifications(self):
+        user = UserFactory()
+        topic = TopicFactory(with_post=True)
+
+        old_notification = NotificationFactory(recipient=user.email, post=topic.first_post, is_sent=True)
+        self.assertNotEqual(str(old_notification.sent_at), str(old_notification.created))
+
+        Notification.objects.mark_topic_posts_read(topic, user)
+
+        old_notification.refresh_from_db()
+        self.assertNotEqual(str(old_notification.sent_at), str(old_notification.created))
+
+    def test_mark_topic_posts_read_doesnt_impact_other_notifications(self):
+        user = UserFactory()
+        topic = TopicFactory(with_post=True)
+
+        other_notification = NotificationFactory(recipient="test@example.com", post=topic.first_post)
+
+        Notification.objects.mark_topic_posts_read(topic, user)
+
+        other_notification.refresh_from_db()
+        self.assertIsNone(other_notification.sent_at)
+
+    def test_mark_topic_posts_read_anonymous_user(self):
+        topic = TopicFactory(with_post=True)
+
+        with self.assertRaises(ValueError):
+            Notification.objects.mark_topic_posts_read(topic, AnonymousUser())
+
+    def test_mark_topic_posts_read_invalid_arguments(self):
+        user = UserFactory()
+        topic = TopicFactory(with_post=True)
+
+        with self.assertRaises(ValueError):
+            Notification.objects.mark_topic_posts_read(None, user)
+
+        with self.assertRaises(ValueError):
+            Notification.objects.mark_topic_posts_read(topic, None)


### PR DESCRIPTION
## Description

🎸 Quand un utilisateur voit un sujet, les notifications liés sont marqués lues
🎸 Adjustment des champs inclus dans la classe `NotificationAdmin`

## Type de changement

🚧 technique

### Captures d'écran (optionnel)

<img width="1043" alt="Screenshot 2024-07-04 at 17 45 45" src="https://github.com/gip-inclusion/itou-communaute-django/assets/10801930/9bd93588-3bf1-4478-b936-0c0eb8cc0992">

