### PR TITLE
fix: mise à jour de la public key sentry pour l'envoi des logs

### DIFF
--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -34,7 +34,7 @@
             <!-- Use this to get the value of the CSRF token in JavaScript. -->
             <meta name="csrf-token" content="{{ csrf_token }}">
             {% if not debug %}
-                <script src="https://js.sentry-cdn.com/df68a3c4bf3344c59bb63010cbeaa92e.min.js" crossorigin="anonymous"></script>
+                <script src="https://js.sentry-cdn.com/315adbc1472b4c5f875aa426db1fe8f2.min.js" crossorigin="anonymous"></script>
             {% endif %}
         {% endblock head %}
         {% block extra_head %}{% endblock %}


### PR DESCRIPTION
## Description

🎸 rollback #723 

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 la clé publique du projet de la communauté dans sentry est `315…8f2`