### PR TITLE
feat(forum): attr accept définit sur forms.ImageField

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -333,6 +333,7 @@ MACHINA_MARKUP_LANGUAGE = (
     "machina.core.markdown.markdown",
     {"safe_mode": False, "extras": {"break-on-newline": True, "code-friendly": True, "nofollow": True}},
 )
+SUPPORTED_IMAGE_FILE_TYPES = {"image/png": "png", "image/jpeg": "jpeg", "image/jpg": "jpg", "image/gif": "gif"}
 
 # Django sites framework
 SITE_ID = 1

--- a/lacommunaute/forum/forms.py
+++ b/lacommunaute/forum/forms.py
@@ -32,7 +32,7 @@ class ForumForm(forms.ModelForm):
     )
     image = forms.ImageField(
         required=False,
-        label="Banniere de couverture",
+        label="Banniere de couverture, format 1200 x 630 pixels recommandé",
         widget=forms.FileInput(attrs={"accept": settings.SUPPORTED_IMAGE_FILE_TYPES.keys()}),
     )
 

--- a/lacommunaute/forum/forms.py
+++ b/lacommunaute/forum/forms.py
@@ -1,6 +1,7 @@
 import re
 
 from django import forms
+from django.conf import settings
 
 from lacommunaute.forum.models import Forum
 
@@ -29,7 +30,11 @@ class ForumForm(forms.ModelForm):
     description = forms.CharField(
         widget=forms.Textarea(attrs={"rows": 20}), required=False, label="Contenu (markdown autorisé)"
     )
-    image = forms.ImageField(required=False, label="Banniere de couverture")
+    image = forms.ImageField(
+        required=False,
+        label="Banniere de couverture",
+        widget=forms.FileInput(attrs={"accept": settings.SUPPORTED_IMAGE_FILE_TYPES.keys()}),
+    )
 
     def save(self, commit=True):
         forum = super().save(commit=False)

--- a/lacommunaute/forum/tests/test_forum_updateview.py
+++ b/lacommunaute/forum/tests/test_forum_updateview.py
@@ -14,7 +14,7 @@ from lacommunaute.users.factories import UserFactory
 @pytest.fixture
 def fake_image():
     fake = Faker()
-    image_name = fake.pystr(min_chars=30, max_chars=40, prefix="pytest_", suffix=".png")
+    image_name = fake.pystr(min_chars=30, max_chars=40, prefix="pytest_", suffix=".jpg")
 
     image = Image.new("RGB", (100, 100))
     image_file = BytesIO()


### PR DESCRIPTION
Quelque chose que je viens d'implementer sur les-emplois, j'ai vu l'occasion de repliquer le travail sur la communauté :)

## Description

🎸 Ajouté une définition des formats d'image acceptés (encouragés) sur les thématiques
🎸 Ajouté un champ dans le settings du projet pour clarifier les formats d'image soutenu. J'ai choisis les formats d'image qui sont [soutenu par le plupart des navigateurs mondiales](https://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support)

## Type de changement

🎨 changement d'UI

### Points d'attention

🦺 J'ai inclus GIF 😁 