### PR TITLE
fix(forum): balise `article` et dimension des images

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -604,7 +604,8 @@ class TestForumDetailContent:
         assert (
             len(
                 content.select(
-                    "div.textarea_cms_md", string=(lambda x: x.startswith(str(forum_for_snapshot.description)[:10]))
+                    "article.textarea_cms_md",
+                    string=(lambda x: x.startswith(str(forum_for_snapshot.description)[:10])),
                 )
             )
             == 1
@@ -656,7 +657,8 @@ class TestDocumentationForumContent:
         assert (
             len(
                 content.select(
-                    "div.textarea_cms_md", string=(lambda x: x.startswith(str(documentation_forum.description)[:10]))
+                    "article.textarea_cms_md",
+                    string=(lambda x: x.startswith(str(documentation_forum.description)[:10])),
                 )
             )
             == 1

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -34,7 +34,7 @@
                 {% if forum.description %}
                     <div class="s-section__row row">
                         <div class="col-12">
-                            <div class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30 }}</div>
+                            <article class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30 }}</article>
                         </div>
                     </div>
                 {% endif %}

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -34,7 +34,7 @@
                 {% if forum.description %}
                     <div class="s-section__row row">
                         <div class="col-12">
-                            <article class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30 }}</article>
+                            <article class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30|img_fluid }}</article>
                         </div>
                     </div>
                 {% endif %}

--- a/lacommunaute/templates/forum/forum_documentation.html
+++ b/lacommunaute/templates/forum/forum_documentation.html
@@ -23,7 +23,7 @@
                     </div>
                 {% endif %}
                 <div class="col-12 col-sm-auto mt-3">
-                    <div class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30 }}</div>
+                    <article class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30 }}</article>
                 </div>
                 {% include "forum/partials/rating.html" with forum=forum rating_area_id="1" %}
             </div>

--- a/lacommunaute/templates/forum/forum_documentation.html
+++ b/lacommunaute/templates/forum/forum_documentation.html
@@ -23,7 +23,7 @@
                     </div>
                 {% endif %}
                 <div class="col-12 col-sm-auto mt-3">
-                    <article class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30 }}</article>
+                    <article class="textarea_cms_md">{{ forum.description.rendered|urlizetrunc_target_blank:30|img_fluid }}</article>
                 </div>
                 {% include "forum/partials/rating.html" with forum=forum rating_area_id="1" %}
             </div>


### PR DESCRIPTION
## Description

🎸 utiliser la balise `article` au lieu de la balise `div` pour la description des `forum`
🎸 appliquer la classe `img-fluid` sur le rendu des images dans la description des `forum`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🎨 changement d'UI
