### PR TITLE
fix(upvote): supprimer un parametrage ambigue

### DIFF
--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -120,7 +120,7 @@
                       </p>
                   </div>
                   <div class="card-footer text-center">
-                      <a class="btn btn-primary matomo-event" data-matomo-action="topic-create-check" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/forum-[PK of Forum]/topic/create/?checked=1">Je pose ma question à la communauté</a>
+                      <a class="btn btn-primary matomo-event" data-matomo-action="topic-create-check" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/forum-[PK of Forum]/topic/create/?checked">Je pose ma question à la communauté</a>
                   </div>
               </div>
           </div>

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -1104,7 +1104,7 @@ class TestTopicCreateCheckView:
         assertContains(
             response,
             reverse("forum_conversation:topic_create", kwargs={"forum_slug": forum.slug, "forum_pk": forum.pk})
-            + "?checked=1",
+            + "?checked",
         )
         content = parse_response_to_soup(response, selector="main", replace_in_href=[forum])
         assert str(content) == snapshot(name="topic_create_check")

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -44,7 +44,7 @@ class TopicCreateView(FormValidMixin, views.TopicCreateView):
 
     def get(self, request, *args, **kwargs):
         forum = self.get_forum()
-        if forum.is_in_documentation_area or self.request.GET.get("checked"):
+        if forum.is_in_documentation_area or "checked" in self.request.GET:
             return super().get(request, *args, **kwargs)
         return redirect(
             reverse(

--- a/lacommunaute/templates/forum_conversation/topic_create_check.html
+++ b/lacommunaute/templates/forum_conversation/topic_create_check.html
@@ -80,7 +80,7 @@
                     </p>
                 </div>
                 <div class="card-footer text-center">
-                    <a href="{% url 'forum_conversation:topic_create' forum.slug forum.id %}?checked=1"
+                    <a href="{% url 'forum_conversation:topic_create' forum.slug forum.id %}?checked"
                        class="btn btn-primary matomo-event"
                        data-matomo-action="topic-create-check"
                        data-matomo-category="engagement"


### PR DESCRIPTION
## Description

🎸 suite #681
🎸 le parametre `?checked=1` génère du bruit dans la suite de test. simplification en `?checked`


## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

