### PR TITLE
feat(tags): ajouter une étiquette inexistante à un sujet

### DIFF
--- a/lacommunaute/forum_conversation/forms.py
+++ b/lacommunaute/forum_conversation/forms.py
@@ -50,6 +50,7 @@ class TopicForm(CreateUpdatePostMixin, AbstractTopicForm):
     tags = ModelMultipleChoiceField(
         label="", queryset=Tag.objects.all(), widget=CheckboxSelectMultiple, required=False
     )
+    new_tags = CharField(required=False, label="Ajouter un tag ou plusieurs tags (séparés par des virgules)")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -59,5 +60,10 @@ class TopicForm(CreateUpdatePostMixin, AbstractTopicForm):
     def save(self):
         post = super().save()
         post.topic.tags.set(self.cleaned_data["tags"])
+        (
+            post.topic.tags.add(*[tag.strip() for tag in self.cleaned_data["new_tags"].split(",")])
+            if self.cleaned_data.get("new_tags")
+            else None
+        )
 
         return post

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -1025,7 +1025,7 @@ class TopicListViewTest(TestCase):
             response,
             (
                 f'<a href="{self.url}?tags={tag.slug}&amp;page=1">'
-                '<span class="badge badge-xs rounded-pill bg-info-lighter '
+                '<span class="tag bg-info-lighter '
                 f'text-info">{ tag.name }</span></a>'
             ),
         )
@@ -1036,7 +1036,7 @@ class TopicListViewTest(TestCase):
             response,
             (
                 f'<a href="{self.url}?tags={tag.slug}&amp;page=1">'
-                '<span class="badge badge-xs rounded-pill bg-info-lighter '
+                '<span class="tag bg-info-lighter '
                 f'text-info">{ tag.name }</span></a>'
             ),
             status_code=200,

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # noqa
 from django.conf import settings
 from django.contrib.messages.api import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
@@ -254,6 +254,38 @@ class TestTopicCreateView:
         assert response.status_code == 200
         content = parse_response_to_soup(response, selector="#div_id_content")
         assert str(content) == snapshot(name="topic_create")
+
+    def test_create_with_new_tags(self, db, client):
+        forum = ForumFactory(with_public_perms=True)
+        client.force_login(UserFactory())
+        tags_list = [faker.word() for i in range(2)]
+        response = client.post(
+            reverse("forum_conversation:topic_create", kwargs={"forum_pk": forum.pk, "forum_slug": forum.slug}),
+            {
+                "subject": faker.sentence(),
+                "content": faker.paragraph(nb_sentences=5),
+                "new_tags": ", ".join(tags_list),
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+
+        queryset = forum.topics.get().tags.filter(name__in=tags_list)
+        assert all(tag in queryset.values_list("name", flat=True) for tag in tags_list)
+
+    def test_create_without_tag(self, db, client):
+        forum = ForumFactory(with_public_perms=True)
+        client.force_login(UserFactory())
+        response = client.post(
+            reverse("forum_conversation:topic_create", kwargs={"forum_pk": forum.pk, "forum_slug": forum.slug}),
+            {
+                "subject": faker.sentence(),
+                "content": faker.paragraph(nb_sentences=5),
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        assert forum.topics.get().tags.count() == 0
 
 
 class TopicUpdateViewTest(TestCase):

--- a/lacommunaute/templates/forum_conversation/partials/post_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_form.html
@@ -31,7 +31,6 @@
                 <br />
                 <div class="row">
                     <div id="attachment_formset" class="col-md-12">
-                        <p class="lead attachments-title">{% trans "Attachments" %}</p>
                         {% include "forum_conversation/forum_attachments/attachment_formset.html" %}
                     </div>
                 </div>

--- a/lacommunaute/templates/forum_conversation/partials/post_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_form.html
@@ -14,6 +14,7 @@
 {% if post_form.update_reason %}
     {% include "partials/form_field.html" with field=post_form.update_reason %}
 {% endif %}
+{% include "partials/form_field.html" with field=post_form.lock_topic %}
 <!-- Sub "forms" tabs -->
 {% if attachment_formset %}
     <ul class="nav nav-tabs nav-tabs--communaute">
@@ -24,25 +25,6 @@
 {% endif %}
 <!-- Sub "forms" panes -->
 <div class="tab-content">
-    <div class="tab-pane active" id="options">
-        <div class="form-group">
-            <br />
-            <div class="row">
-                <div class="col-md-12">
-                    {% if post_form.lock_topic %}
-                        {% with field=post_form.lock_topic %}
-                            <div class="checkbox">
-                                <label for="{{ field.auto_id }}">
-                                    {{ field }}
-                                    {{ field.label }}
-                                </label>
-                            </div>
-                        {% endwith %}
-                    {% endif %}
-                </div>
-            </div>
-        </div>
-    </div>
     {% if attachment_formset %}
         <div class="tab-pane" id="attachments">
             <div class="form-group">

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -36,7 +36,7 @@
         </ul>
     {% endif %}
     <!-- Sub "forms" panes -->
-    <div class="tab-content">
+    <div class="tab-content mt-3">
         <div class="tab-pane" id="tags">
             <div class="row">
                 <div id="tags_formset" class="col-md-12">{% include "partials/form_field.html" with field=post_form.tags %}</div>

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -40,6 +40,7 @@
         <div class="tab-pane" id="tags">
             <div class="row">
                 <div id="tags_formset" class="col-md-12">{% include "partials/form_field.html" with field=post_form.tags %}</div>
+                {% include "partials/form_field.html" with field=post_form.new_tags %}
             </div>
         </div>
         {% if poll_option_formset %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -16,6 +16,7 @@
     {% if post_form.update_reason %}
         {% include "partials/form_field.html" with field=post_form.update_reason %}
     {% endif %}
+    {% include "partials/form_field.html" with field=post_form.lock_topic %}
     <!-- Sub "forms" tabs -->
     {% if poll_option_formset or attachment_formset %}
         <ul class="nav nav-tabs nav-tabs--communaute border-bottom-0">
@@ -36,22 +37,6 @@
     {% endif %}
     <!-- Sub "forms" panes -->
     <div class="tab-content">
-        <div class="tab-pane active" id="options">
-            <div class="row">
-                <div class="col-md-12">
-                    {% if post_form.lock_topic %}
-                        <div class="form-group">
-                            {% with field=post_form.lock_topic %}
-                                <div class="form-check mt-2">
-                                    {{ field | add_class:'form-check-input' }}
-                                    <label class="form-check-label" for="{{ field.auto_id }}">{{ field.label }}</label>
-                                </div>
-                            {% endwith %}
-                        </div>
-                    {% endif %}
-                </div>
-            </div>
-        </div>
         <div class="tab-pane" id="tags">
             <div class="row">
                 <div id="tags_formset" class="col-md-12">{% include "partials/form_field.html" with field=post_form.tags %}</div>

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,4 +1,4 @@
 {% load url_add_query %}
 {% for tag in tags %}
-    <a href="{% url_add_query request.get_full_path tags=tag.slug page=1 %}"><span class="badge badge-xs rounded-pill bg-info-lighter text-info">{{ tag }}</span></a>
+    <a href="{% url_add_query request.get_full_path tags=tag.slug page=1 %}"><span class="tag bg-info-lighter text-info">{{ tag }}</span></a>
 {% endfor %}

--- a/lacommunaute/templates/partials/form_field.html
+++ b/lacommunaute/templates/partials/form_field.html
@@ -2,7 +2,10 @@
 {% load widget_tweaks %}
 <div id="div_id_{{ field.html_name }}" class="form-group{% if field.errors %} has-error{% endif %}">
     {% if field|widget_type == "checkboxinput" %}
-        <div class="checkbox">{{ field }} {{ field.label }}</div>
+        <div class="form-check mt-2">
+            {{ field | add_class:'form-check-input' }}
+            <label class="form-check-label" for="{{ field.auto_id }}">{{ field.label }}</label>
+        </div>
     {% else %}
         {% if field.label %}
             <label class="control-label" for="{{ field.auto_id }}">

--- a/lacommunaute/templates/partials/form_field.html
+++ b/lacommunaute/templates/partials/form_field.html
@@ -19,7 +19,7 @@
             {% for checkbox in field %}
                 <div class="form-check form-check-inline">
                     <input id="{{ checkbox.id_for_label }}" class="form-check-input" type="checkbox" name="{{ checkbox.data.name }}" value="{{ checkbox.data.value }}" {% if checkbox.data.selected %}checked=""{% endif %}>
-                    <label class="form-check-label badge badge-sm rounded-pill bg-info-lighter text-info" for="{{ checkbox.id_for_label }}">
+                    <label class="form-check-label tag bg-info-lighter text-info" for="{{ checkbox.id_for_label }}">
                         {{ checkbox.choice_label }}
                     </label>
                 </div>


### PR DESCRIPTION
## Description

🎸 Les formulaires de création et mise à jour de `Topic` doit permettre d'ajouter un `tag` qui n'existe pas encore

ISSUE #726 partie 1

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🎨 changement d'UI

### Points d'attention

🦺 PR préparatoire à l'ajout de `tag` sur les `Forum`
🦺 UI fix : déplacer la case `verrouiller le sujet` en dehors du panneau "Etiquette"
🦺 UI fix : mise à jour du format de la case à cocher `checkboxinput` dans le template `partials/form_field`
🎨 mise à jour class `tag` sur les tags en remplacement des badges

### Captures d'écran (optionnel)

Nouveau sujet

![image](https://github.com/user-attachments/assets/eeae80d0-5bb6-4f05-a70d-e217d79d79cb)

Mise à jour d'un sujet existant (case "Verrouiller le sujet")

![image](https://github.com/user-attachments/assets/de4f5564-0807-4f70-bd98-cab269cdd4e1)

Vue d'un tag sur un message au format `tag`

![image](https://github.com/user-attachments/assets/2b9384eb-0162-45ab-8a49-dba1a247d616)

