### PR TITLE
feat(tags): filtrer les `forum` enfants à partir des tags

### DIFF
--- a/lacommunaute/forum/tests/__snapshots__/test_forum_updateview.ambr
+++ b/lacommunaute/forum/tests/__snapshots__/test_forum_updateview.ambr
@@ -2,50 +2,50 @@
 # name: test_selected_tags_are_preloaded[selected_tags_preloaded]
   '''
   <div class="form-group" id="div_id_tags">
-      
-          
+
+
               <label class="control-label" for="id_tags">
                   Sélectionner un ou plusieurs tags
-                  
+
                       <span class="text-muted">(optional)</span>
-                  
+
               </label>
-          
-          
-              
+
+
+
                   <div class="form-check form-check-inline">
                       <input checked="" class="form-check-input" id="id_tags_0" name="tags" type="checkbox" value="9999"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_0">
                           iae
                       </label>
                   </div>
-              
+
                   <div class="form-check form-check-inline">
                       <input checked="" class="form-check-input" id="id_tags_1" name="tags" type="checkbox" value="10000"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_1">
                           siae
                       </label>
                   </div>
-              
+
                   <div class="form-check form-check-inline">
                       <input checked="" class="form-check-input" id="id_tags_2" name="tags" type="checkbox" value="10001"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_2">
                           prescripteur
                       </label>
                   </div>
-              
+
                   <div class="form-check form-check-inline">
                       <input class="form-check-input" id="id_tags_3" name="tags" type="checkbox" value="10002"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_3">
                           undesired_tag
                       </label>
                   </div>
-              
-          
-      
-      
-      
-      
+
+
+
+
+
+
   </div>
   '''
 # ---

--- a/lacommunaute/forum/tests/__snapshots__/test_forum_updateview.ambr
+++ b/lacommunaute/forum/tests/__snapshots__/test_forum_updateview.ambr
@@ -2,50 +2,50 @@
 # name: test_selected_tags_are_preloaded[selected_tags_preloaded]
   '''
   <div class="form-group" id="div_id_tags">
-
-
+      
+          
               <label class="control-label" for="id_tags">
                   Sélectionner un ou plusieurs tags
-
+                  
                       <span class="text-muted">(optional)</span>
-
+                  
               </label>
-
-
-
+          
+          
+              
                   <div class="form-check form-check-inline">
                       <input checked="" class="form-check-input" id="id_tags_0" name="tags" type="checkbox" value="9999"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_0">
                           iae
                       </label>
                   </div>
-
+              
                   <div class="form-check form-check-inline">
                       <input checked="" class="form-check-input" id="id_tags_1" name="tags" type="checkbox" value="10000"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_1">
                           siae
                       </label>
                   </div>
-
+              
                   <div class="form-check form-check-inline">
                       <input checked="" class="form-check-input" id="id_tags_2" name="tags" type="checkbox" value="10001"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_2">
                           prescripteur
                       </label>
                   </div>
-
+              
                   <div class="form-check form-check-inline">
                       <input class="form-check-input" id="id_tags_3" name="tags" type="checkbox" value="10002"/>
                       <label class="form-check-label tag bg-info-lighter text-info" for="id_tags_3">
                           undesired_tag
                       </label>
                   </div>
-
-
-
-
-
-
+              
+          
+      
+      
+      
+      
   </div>
   '''
 # ---

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -671,23 +671,37 @@ class TestDocumentationCategoryForumContent:
         assert str(add_documentation_control[0]) == snapshot(name="documentation_category_add_file_control")
 
     def test_filter_subforums_on_tags(self, client, db):
-        tag = faker.word()
-        category_forum = CategoryForumFactory(with_public_perms=True, with_child=True)
-        second_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tag])
-        third_child = ForumFactory(parent=category_forum, with_public_perms=True)
+        tags = [faker.word() for _ in range(3)]
+        category_forum = CategoryForumFactory(with_public_perms=True)
+        first_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[0]])
+        second_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[0], tags[1]])
+        third_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[2]])
+        # forum without tags
+        ForumFactory(parent=category_forum, with_public_perms=True)
 
         # edge case: grand_child is filtered out. No actual use case to display them in the subforum list
-        ForumFactory(parent=third_child, with_public_perms=True, with_tags=[tag])
+        ForumFactory(parent=third_child, with_public_perms=True, with_tags=[tags[2]])
 
+        # no filter
         response = client.get(category_forum.get_absolute_url())
         assert response.status_code == 200
         assert [node.obj for node in response.context_data["sub_forums"].top_nodes] == list(
             category_forum.get_children()
         )
 
-        response = client.get(category_forum.get_absolute_url() + f"?forum_tags={tag}")
+        # filter on first tag
+        response = client.get(category_forum.get_absolute_url() + f"?forum_tags={tags[0]}")
         assert response.status_code == 200
-        assert [node.obj for node in response.context_data["sub_forums"].top_nodes] == [second_child]
+        assert set([node.obj for node in response.context_data["sub_forums"].top_nodes]) == set(
+            [first_child, second_child]
+        )
+
+        # filter on multiple tags
+        response = client.get(category_forum.get_absolute_url() + f"?forum_tags={tags[1]},{tags[2]}")
+        assert response.status_code == 200
+        assert set([node.obj for node in response.context_data["sub_forums"].top_nodes]) == set(
+            [second_child, third_child]
+        )
 
 
 @pytest.fixture(name="discussion_area_forum")


### PR DESCRIPTION
## Description

🎸 Réduire la liste des `Forum` enfants affichés en filtrant sur leurs tags

suite #746 

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Affichage des enfants, les petits-enfants ne sont pas considérés, qu'il possède le tag ou non

### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/6042fdf1-90e6-4e20-abd9-829bab8e8d0f)
