### PR TITLE
chore: mise à jour de CSP_IMG_SRC pour le profile django x docker-compose

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -61,4 +61,4 @@ EMAIL_USE_TLS = False
 MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"  # noqa: F405
 
 CSP_DEFAULT_SRC = ("*",)
-CSP_IMG_SRC += ("localhost:9000",)  # noqa: F405
+CSP_IMG_SRC += ("localhost:9000", "minio:9000")  # noqa: F405


### PR DESCRIPTION
## Description

🎸 rendre le bucket S3 `minio` disponible en environnement de dev, lorsque `django` est executé par `docker-compose`

## Type de changement

🚧 technique
