### PR TITLE
fix: mise à jour des urls de statistiques

### DIFF
--- a/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
+++ b/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
@@ -95,11 +95,6 @@
                   <div class="s-footer-gip__col s-footer-gip__col--links col-12 col-lg-auto">
                       <ul>
                           <li>
-                              <a aria-label="France Travail (lien externe)" href="https://www.francetravail.fr/accueil/">
-                                  <img alt="France Travail" height="40" src="/static/vendor/theme-inclusion/images/logo-france-travail.svg"/>
-                              </a>
-                          </li>
-                          <li>
                               <a aria-label="Incubateur de services publics numériques — beta.gouv.fr (lien externe)" href="https://beta.gouv.fr/" target="_blank">beta.gouv.fr</a>
                           </li>
                           <li>

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -30,8 +30,6 @@
               <div class="s-title-01__row row">
                   <div class="s-title-01__col col-12">
                       <h1 class="s-title-01__title h1">
-                          <strong>Partenariat Academie France Travail x La communauté de l'inclusion</strong>
-                          <br/>
                           Statistiques de la semaine du 20 mai 2024 au 26 mai 2024
                       </h1>
                   </div>

--- a/lacommunaute/stats/urls.py
+++ b/lacommunaute/stats/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     path("", StatistiquesPageView.as_view(), name="statistiques"),
     path("monthly-visitors/", MonthlyVisitorsView.as_view(), name="monthly_visitors"),
     path("dsp/", DailyDSPView.as_view(), name="dsp"),
-    path("aft/<int:year>/<int:week>/", ForumStatWeekArchiveView.as_view(), name="forum_stat_week_archive"),
+    path("weekly/<int:year>/<int:week>/", ForumStatWeekArchiveView.as_view(), name="forum_stat_week_archive"),
 ]

--- a/lacommunaute/templates/partials/footer.html
+++ b/lacommunaute/templates/partials/footer.html
@@ -102,11 +102,6 @@
                 <div class="s-footer-gip__col s-footer-gip__col--links col-12 col-lg-auto">
                     <ul>
                         <li>
-                            <a href="https://www.francetravail.fr/accueil/" aria-label="France Travail (lien externe)">
-                                <img src="{% static_theme_images 'logo-france-travail.svg' %}" height="40" alt="France Travail">
-                            </a>
-                        </li>
-                        <li>
                             <a href="https://beta.gouv.fr/" target="_blank" aria-label="Incubateur de services publics numériques — beta.gouv.fr (lien externe)">beta.gouv.fr</a>
                         </li>
                         <li>

--- a/lacommunaute/templates/stats/forum_stat_week_archive.html
+++ b/lacommunaute/templates/stats/forum_stat_week_archive.html
@@ -23,8 +23,6 @@
             <div class="s-title-01__row row">
                 <div class="s-title-01__col col-12">
                     <h1 class="s-title-01__title h1">
-                        <strong>Partenariat Academie France Travail x La communauté de l'inclusion</strong>
-                        <br>
                         Statistiques de la semaine du {{ week|date:"j F Y" }} au {{ end_date|date:"j F Y" }}
                     </h1>
                 </div>


### PR DESCRIPTION
## Description

🎸 pour plus de consistence

## Type de changement

🚧 technique

### Points d'attention

🦺 nouvelle route pour les stats hebdo : `/statistiques/weekly/YYYY/WW/`


### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/ac1918ac-8ec2-48fb-a41b-783768f6c655)
