### PR TITLE
feat(stats): ajout d'un lien vers la page de stats hebdos

### DIFF
--- a/lacommunaute/stats/factories.py
+++ b/lacommunaute/stats/factories.py
@@ -39,3 +39,4 @@ class ForumStatFactory(factory.django.DjangoModelFactory):
 
     class Params:
         for_snapshot = factory.Trait(period="week", date=datetime.date(2024, 5, 20))
+        for_snapshot_older = factory.Trait(period="week", date=datetime.date(2024, 5, 13))

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -43,7 +43,9 @@
   <div class="s-section__row row" id="most_rated">
                   <div class="s-section__col col-12">
                       <div class="c-box mb-3 mb-md-5">
-                          <h2>Les 1 fiches pratiques les plus notées sur la période</h2>
+                          <h2>
+                              Les 1 fiches pratiques les plus notées pendant la semaine du 20 mai 2024 au 26 mai 2024
+                          </h2>
                           <table class="table">
                               <thead>
                                   <tr>
@@ -72,7 +74,9 @@
   <div class="s-section__row row" id="most_viewed">
                   <div class="s-section__col col-12">
                       <div class="c-box mb-3 mb-md-5">
-                          <h2>Les 2 fiches pratiques les plus lues sur la période</h2>
+                          <h2>
+                              Les 2 fiches pratiques les plus lues pendant la semaine du 20 mai 2024 au 26 mai 2024
+                          </h2>
                           <table class="table">
                               <thead>
                                   <tr>

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -167,6 +167,12 @@ class TestStatistiquesPageView:
         assert response.status_code == 200
         assert response.context["stats"] == expected
 
+    def test_link_to_weekly_lastest_stats_view(self, client, db):
+        url = reverse("stats:statistiques")
+        response = client.get(url)
+        assert response.status_code == 200
+        assertContains(response, reverse("stats:redirect_to_latest_weekly_stats"))
+
 
 class TestMonthlyVisitorsView:
     def test_context_data(self, client, db):

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -346,3 +346,21 @@ class TestForumStatWeekArchiveView:
             "nb_uniq_engaged_visitors": [],
         }
         assert response.context_data["stats"] == expected_stats
+
+
+@pytest.mark.parametrize(
+    "forum_stat,status_code",
+    [
+        (lambda: None, 404),
+        (lambda: ForumStatFactory(period="week", for_snapshot=True), 302),
+    ],
+)
+def test_redirect_to_latest_weekly_stats(client, db, forum_stat, status_code):
+    forum_stat = forum_stat()
+    response = client.get(reverse("stats:redirect_to_latest_weekly_stats"))
+    assert response.status_code == status_code
+    if forum_stat:
+        assert response.url == reverse(
+            "stats:forum_stat_week_archive",
+            kwargs={"year": forum_stat.date.year, "week": forum_stat.date.strftime("%W")},
+        )

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -355,18 +355,18 @@ class TestForumStatWeekArchiveView:
 
 
 @pytest.mark.parametrize(
-    "forum_stat,status_code",
+    "forum_stats,status_code",
     [
         (lambda: None, 404),
-        (lambda: ForumStatFactory(period="week", for_snapshot=True), 302),
+        (lambda: [ForumStatFactory(for_snapshot=True), ForumStatFactory(for_snapshot_older=True)], 302),
     ],
 )
-def test_redirect_to_latest_weekly_stats(client, db, forum_stat, status_code):
-    forum_stat = forum_stat()
+def test_redirect_to_latest_weekly_stats(client, db, forum_stats, status_code):
+    forum_stats = forum_stats()
     response = client.get(reverse("stats:redirect_to_latest_weekly_stats"))
     assert response.status_code == status_code
-    if forum_stat:
+    if forum_stats:
         assert response.url == reverse(
             "stats:forum_stat_week_archive",
-            kwargs={"year": forum_stat.date.year, "week": forum_stat.date.strftime("%W")},
+            kwargs={"year": forum_stats[0].date.year, "week": forum_stats[0].date.strftime("%W")},
         )

--- a/lacommunaute/stats/urls.py
+++ b/lacommunaute/stats/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path
 
-from lacommunaute.stats.views import DailyDSPView, ForumStatWeekArchiveView, MonthlyVisitorsView, StatistiquesPageView
+from lacommunaute.stats.views import (
+    DailyDSPView,
+    ForumStatWeekArchiveView,
+    MonthlyVisitorsView,
+    StatistiquesPageView,
+    redirect_to_latest_weekly_stats,
+)
 
 
 app_name = "stats"
@@ -10,4 +16,5 @@ urlpatterns = [
     path("monthly-visitors/", MonthlyVisitorsView.as_view(), name="monthly_visitors"),
     path("dsp/", DailyDSPView.as_view(), name="dsp"),
     path("weekly/<int:year>/<int:week>/", ForumStatWeekArchiveView.as_view(), name="forum_stat_week_archive"),
+    path("weekly/", redirect_to_latest_weekly_stats, name="redirect_to_latest_weekly_stats"),
 ]

--- a/lacommunaute/stats/views.py
+++ b/lacommunaute/stats/views.py
@@ -4,6 +4,8 @@ import logging
 from dateutil.relativedelta import relativedelta
 from django.db.models import Avg, CharField, Count, Q
 from django.db.models.functions import Cast
+from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.utils.dateformat import format
 from django.utils.timezone import localdate
 from django.views.generic.base import TemplateView
@@ -160,3 +162,17 @@ class ForumStatWeekArchiveView(WeekArchiveView):
         context["stats"] = get_daily_visits_stats(from_date=end_date - relativedelta(days=89), to_date=end_date)
         context["rated_forums"] = self.get_most_rated_forums(start_date, end_date)
         return context
+
+
+def redirect_to_latest_weekly_stats(request):
+    latest_weekly_stat = ForumStat.objects.filter(period="week").order_by("-date").first()
+
+    if latest_weekly_stat:
+        return redirect(
+            reverse(
+                "stats:forum_stat_week_archive",
+                kwargs={"year": latest_weekly_stat.date.year, "week": latest_weekly_stat.date.strftime("%W")},
+            )
+        )
+
+    return render(request, "404.html", status=404)

--- a/lacommunaute/templates/stats/forum_stat_week_archive.html
+++ b/lacommunaute/templates/stats/forum_stat_week_archive.html
@@ -31,22 +31,12 @@
     </section>
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="s-section__row row">
-                <div class="s-section__col col-12">
-                    <div class="c-box mb-3 mb-md-5">
-                        <h2>Trafic global sur la période</h2>
-                        <canvas id="statChart"></canvas>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </section>
-    <section class="s-section">
-        <div class="s-section__container container">
             <div class="s-section__row row" id="most_viewed">
                 <div class="s-section__col col-12">
                     <div class="c-box mb-3 mb-md-5">
-                        <h2>Les {{ object_list|length }} fiches pratiques les plus lues sur la période</h2>
+                        <h2>
+                            Les {{ object_list|length }} fiches pratiques les plus lues pendant la semaine du {{ week|date:"j F Y" }} au {{ end_date|date:"j F Y" }}
+                        </h2>
                         <table class="table">
                             <thead>
                                 <tr>
@@ -77,7 +67,9 @@
             <div class="s-section__row row" id="most_rated">
                 <div class="s-section__col col-12">
                     <div class="c-box mb-3 mb-md-5">
-                        <h2>Les {{ rated_forums|length }} fiches pratiques les plus notées sur la période</h2>
+                        <h2>
+                            Les {{ rated_forums|length }} fiches pratiques les plus notées pendant la semaine du {{ week|date:"j F Y" }} au {{ end_date|date:"j F Y" }}
+                        </h2>
                         <table class="table">
                             <thead>
                                 <tr>
@@ -96,6 +88,18 @@
                                 {% endfor %}
                             </tbody>
                         </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    <div class="c-box mb-3 mb-md-5">
+                        <h2>Trafic quotidien jusqu'au {{ end_date|date:"j F Y" }}</h2>
+                        <canvas id="statChart"></canvas>
                     </div>
                 </div>
             </div>

--- a/lacommunaute/templates/stats/statistiques.html
+++ b/lacommunaute/templates/stats/statistiques.html
@@ -97,6 +97,13 @@
                     </div>
                 </div>
             </div>
+            <div class="s-section__row row">
+                <div class="col-12 col-lg-auto">
+                    <a href="{% url 'stats:redirect_to_latest_weekly_stats' %}" class="btn btn-outline-primary btn-ico btn-block">
+                        Accès aux statistiques hebdomadaires
+                    </a>
+                </div>
+            </div>
         </div>
     </section>
 {% endblock %}


### PR DESCRIPTION
## Description

🎸 Vue de redirection vers la plus récente `ForumStatWeekArchiveView` possible, sinon `404`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Captures d'écran (optionnel)

vue de la page stats avec le nouveau lien sous forme de bouton

![image](https://github.com/user-attachments/assets/3d300d72-95ab-4eed-b3b0-865bbb24bfa6)

vue des nouveaux titres de section de la page hebdo

![image](https://github.com/user-attachments/assets/8bf9593a-c76a-4100-b566-c8f1fe8744fd)

