### PR TITLE
feat(partner): ajout des pages de creation / mise à jour depuis la page "nos partenaires"

### DIFF
--- a/lacommunaute/forum/forms.py
+++ b/lacommunaute/forum/forms.py
@@ -1,5 +1,3 @@
-import re
-
 from django import forms
 from django.conf import settings
 from django.forms import CharField, CheckboxSelectMultiple, ModelMultipleChoiceField
@@ -7,19 +5,7 @@ from taggit.models import Tag
 
 from lacommunaute.forum.models import Forum
 from lacommunaute.partner.models import Partner
-
-
-def wrap_iframe_in_div_tag(text):
-    # iframe tags must be wrapped in a div tag to be displayed correctly
-    # add div tag if not present
-
-    iframe_regex = r"((<div>)?<iframe.*?</iframe>(</div>)?)"
-
-    for match, starts_with, ends_with in re.findall(iframe_regex, text, re.DOTALL):
-        if not starts_with and not ends_with:
-            text = text.replace(match, f"<div>{match}</div>")
-
-    return text
+from lacommunaute.utils.html import wrap_iframe_in_div_tag
 
 
 class ForumForm(forms.ModelForm):

--- a/lacommunaute/forum/tests/tests_forms.py
+++ b/lacommunaute/forum/tests/tests_forms.py
@@ -1,25 +1,8 @@
 import pytest  # noqa
 
-from lacommunaute.forum.forms import wrap_iframe_in_div_tag
 
 from lacommunaute.forum.forms import ForumForm
 from lacommunaute.forum.models import Forum
-
-
-def test_wrap_iframe_in_div_tag():
-    inputs = [
-        "<iframe src='xxx'></iframe>",
-        "<div><iframe src='yyy'></iframe></div>",
-        "<div><iframe src='zzz'></iframe>",
-        "<iframe src='www'></iframe></div>",
-    ]
-    outputs = [
-        "<div><iframe src='xxx'></iframe></div>",
-        "<div><iframe src='yyy'></iframe></div>",
-        "<div><iframe src='zzz'></iframe>",
-        "<iframe src='www'></iframe></div>",
-    ]
-    assert wrap_iframe_in_div_tag(" ".join(inputs)) == " ".join(outputs)
 
 
 def test_saved_forum_description(db):

--- a/lacommunaute/partner/forms.py
+++ b/lacommunaute/partner/forms.py
@@ -1,0 +1,26 @@
+from django import forms
+from django.conf import settings
+
+from lacommunaute.partner.models import Partner
+from lacommunaute.utils.html import wrap_iframe_in_div_tag
+
+
+class PartnerForm(forms.ModelForm):
+    logo = forms.ImageField(
+        required=False,
+        label="Logo, format 200 x 200 pixels recommandé",
+        widget=forms.FileInput(attrs={"accept": settings.SUPPORTED_IMAGE_FILE_TYPES.keys()}),
+    )
+
+    def save(self, commit=True):
+        partner = super().save(commit=False)
+        partner.description = wrap_iframe_in_div_tag(self.cleaned_data.get("description"))
+
+        if commit:
+            partner.save()
+
+        return partner
+
+    class Meta:
+        model = Partner
+        fields = ("name", "short_description", "description", "logo", "url")

--- a/lacommunaute/partner/tests/__snapshots__/tests_partner_detailview.ambr
+++ b/lacommunaute/partner/tests/__snapshots__/tests_partner_detailview.ambr
@@ -92,7 +92,7 @@
                           <h1 class="mb-0">Best Partner Ever</h1>
                       </div>
                       
-                          <a href="/admin/partner/partner/[PK of Partner]/change/"><small>Mettre à jour</small></a>
+                          <a href="/partenaires/best-partner-ever-[PK of Partner]/update/"><small>Mettre à jour</small></a>
                       
                       <h2 class="mt-3">short description for SEO</h2>
                   </div>

--- a/lacommunaute/partner/tests/tests_forms.py
+++ b/lacommunaute/partner/tests/tests_forms.py
@@ -1,0 +1,28 @@
+import pytest  # noqa
+
+from lacommunaute.partner.forms import PartnerForm
+from lacommunaute.partner.models import Partner
+
+
+def test_saved_partner_description(db):
+    form = PartnerForm(
+        data={
+            "name": "test",
+            "short_description": "test",
+            "description": "Text\n<iframe src='xxx'></iframe>\ntext\n<div><iframe src='yyy'></iframe></div>\nbye",
+        }
+    )
+    assert form.is_valid()
+    partner = form.save()
+    assert partner.description.rendered == (
+        "<p>Text</p>\n\n<div><iframe src='xxx'></iframe></div>\n\n"
+        "<p>text</p>\n\n<div><iframe src='yyy'></iframe></div>\n\n<p>bye</p>"
+    )
+
+
+def test_form_field():
+    form = PartnerForm()
+    assert form.Meta.model == Partner
+    assert form.Meta.fields == ("name", "short_description", "description", "logo", "url")
+    assert form.fields["name"].required
+    assert list(form.fields["logo"].widget.attrs["accept"]) == ["image/png", "image/jpeg", "image/jpg", "image/gif"]

--- a/lacommunaute/partner/tests/tests_partner_createview.py
+++ b/lacommunaute/partner/tests/tests_partner_createview.py
@@ -1,0 +1,51 @@
+import pytest  # noqa
+
+from django.urls import reverse
+
+from lacommunaute.users.factories import UserFactory
+from lacommunaute.partner.models import Partner
+
+
+@pytest.fixture(name="url")
+def url_fixture():
+    return reverse("partner:create")
+
+
+@pytest.fixture(name="superuser")
+def superuser_fixture():
+    return UserFactory(is_superuser=True)
+
+
+@pytest.mark.parametrize(
+    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
+)
+def test_user_passes_test_mixin(client, db, url, user, status_code):
+    if user:
+        client.force_login(user())
+    response = client.get(url)
+    assert response.status_code == status_code
+
+
+def test_view(client, db, url, superuser):
+    client.force_login(superuser)
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.context["title"] == "Créer une nouvelle page partenaire"
+    assert response.context["back_url"] == reverse("partner:list")
+    assert list(response.context["form"].fields.keys()) == ["name", "short_description", "description", "logo", "url"]
+
+
+def test_post_partner(client, db, url, superuser):
+    client.force_login(superuser)
+    data = {
+        "name": "Test",
+        "short_description": "Short description",
+        "description": "# Titre\n<iframe src='https://www.example.com'></iframe>",
+        "url": "https://www.example.com",
+    }
+    response = client.post(url, data)
+    assert response.status_code == 302
+
+    partner = Partner.objects.get()
+    assert response.url == reverse("partner:detail", kwargs={"pk": partner.pk, "slug": partner.slug})
+    assert partner.description.raw == "# Titre\n<div><iframe src='https://www.example.com'></iframe></div>"

--- a/lacommunaute/partner/tests/tests_partner_listview.py
+++ b/lacommunaute/partner/tests/tests_partner_listview.py
@@ -5,17 +5,22 @@ from lacommunaute.partner.factories import PartnerFactory
 from lacommunaute.utils.testing import parse_response_to_soup
 
 
-def test_listview(client, db, snapshot):
+@pytest.fixture(name="url")
+def url_fixture():
+    return reverse("partner:list")
+
+
+def test_listview(client, db, snapshot, url):
     partner = PartnerFactory(for_snapshot=True, with_logo=True)
-    response = client.get(reverse("partner:list"))
+    response = client.get(url)
     assert response.status_code == 200
     assert str(
         parse_response_to_soup(response, selector="#partner-list", replace_img_src=True, replace_in_href=[partner])
     ) == snapshot(name="partner_listview")
 
 
-def test_pagination(client, db, snapshot):
+def test_pagination(client, db, snapshot, url):
     PartnerFactory.create_batch(8 * 3 + 1)
-    response = client.get(reverse("partner:list"))
+    response = client.get(url)
     assert response.status_code == 200
     assert str(parse_response_to_soup(response, selector="ul.pagination")) == snapshot(name="partner_pagination")

--- a/lacommunaute/partner/tests/tests_partner_listview.py
+++ b/lacommunaute/partner/tests/tests_partner_listview.py
@@ -2,6 +2,7 @@ import pytest  # noqa
 from django.urls import reverse
 
 from lacommunaute.partner.factories import PartnerFactory
+from lacommunaute.users.factories import UserFactory
 from lacommunaute.utils.testing import parse_response_to_soup
 
 
@@ -24,3 +25,15 @@ def test_pagination(client, db, snapshot, url):
     response = client.get(url)
     assert response.status_code == 200
     assert str(parse_response_to_soup(response, selector="ul.pagination")) == snapshot(name="partner_pagination")
+
+
+@pytest.mark.parametrize(
+    "user,link_is_visible",
+    [(None, False), (lambda: UserFactory(), False), (lambda: UserFactory(is_superuser=True), True)],
+)
+def test_link_to_createview(client, db, url, user, link_is_visible):
+    if user:
+        client.force_login(user())
+    response = client.get(url)
+    assert response.status_code == 200
+    assert bool(reverse("partner:create") in response.content.decode()) == link_is_visible

--- a/lacommunaute/partner/tests/tests_partner_updateview.py
+++ b/lacommunaute/partner/tests/tests_partner_updateview.py
@@ -1,0 +1,56 @@
+import pytest  # noqa
+
+from django.urls import reverse
+
+from lacommunaute.partner.factories import PartnerFactory
+from lacommunaute.users.factories import UserFactory
+
+
+@pytest.fixture(name="partner")
+def partner_fixture():
+    return PartnerFactory(for_snapshot=True)
+
+
+@pytest.fixture(name="url")
+def url_fixture(partner):
+    return reverse("partner:update", kwargs={"pk": partner.id, "slug": partner.slug})
+
+
+@pytest.fixture(name="superuser")
+def superuser_fixture():
+    return UserFactory(is_superuser=True)
+
+
+@pytest.mark.parametrize(
+    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
+)
+def test_user_passes_test_mixin(client, db, url, user, status_code):
+    if user:
+        client.force_login(user())
+    response = client.get(url)
+    assert response.status_code == status_code
+
+
+def test_view(client, db, url, superuser, partner):
+    client.force_login(superuser)
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response.context["title"] == f"Modifier la page {partner.name}"
+    assert response.context["back_url"] == reverse("partner:detail", kwargs={"pk": partner.pk, "slug": partner.slug})
+    assert list(response.context["form"].fields.keys()) == ["name", "short_description", "description", "logo", "url"]
+
+
+def test_post_partner(client, db, url, superuser, partner):
+    client.force_login(superuser)
+    data = {
+        "name": "Test",
+        "short_description": "Short description",
+        "description": "# Titre\ndescription",
+        "url": "https://www.example.com",
+    }
+    response = client.post(url, data)
+    assert response.status_code == 302
+
+    partner.refresh_from_db()
+    assert response.url == reverse("partner:detail", kwargs={"pk": partner.pk, "slug": partner.slug})
+    assert partner.description.rendered == "<h1>Titre</h1>\n\n<p>description</p>"

--- a/lacommunaute/partner/urls.py
+++ b/lacommunaute/partner/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from lacommunaute.partner.views import PartnerCreateView, PartnerDetailView, PartnerListView
+from lacommunaute.partner.views import PartnerCreateView, PartnerDetailView, PartnerListView, PartnerUpdateView
 
 
 app_name = "partner"
@@ -9,5 +9,6 @@ app_name = "partner"
 urlpatterns = [
     path("", PartnerListView.as_view(), name="list"),
     path("<str:slug>-<int:pk>/", PartnerDetailView.as_view(), name="detail"),
+    path("<str:slug>-<int:pk>/update/", PartnerUpdateView.as_view(), name="update"),
     path("create/", PartnerCreateView.as_view(), name="create"),
 ]

--- a/lacommunaute/partner/urls.py
+++ b/lacommunaute/partner/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from lacommunaute.partner.views import PartnerDetailView, PartnerListView
+from lacommunaute.partner.views import PartnerCreateView, PartnerDetailView, PartnerListView
 
 
 app_name = "partner"
@@ -9,4 +9,5 @@ app_name = "partner"
 urlpatterns = [
     path("", PartnerListView.as_view(), name="list"),
     path("<str:slug>-<int:pk>/", PartnerDetailView.as_view(), name="detail"),
+    path("create/", PartnerCreateView.as_view(), name="create"),
 ]

--- a/lacommunaute/partner/views.py
+++ b/lacommunaute/partner/views.py
@@ -1,6 +1,9 @@
-from django.views.generic import DetailView, ListView
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.urls import reverse
+from django.views.generic import CreateView, DetailView, ListView
 
 from lacommunaute.forum.models import Forum
+from lacommunaute.partner.forms import PartnerForm
 from lacommunaute.partner.models import Partner
 from lacommunaute.utils.perms import forum_visibility_content_tree_from_forums
 
@@ -23,3 +26,21 @@ class PartnerDetailView(DetailView):
             self.request, Forum.objects.filter(partner=self.object)
         )
         return context
+
+
+class PartnerCreateView(UserPassesTestMixin, CreateView):
+    model = Partner
+    template_name = "partner/create_or_update.html"
+    form_class = PartnerForm
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = "Créer une nouvelle page partenaire"
+        context["back_url"] = reverse("partner:list")
+        return context
+
+    def get_success_url(self):
+        return reverse("partner:detail", kwargs={"pk": self.object.pk, "slug": self.object.slug})

--- a/lacommunaute/partner/views.py
+++ b/lacommunaute/partner/views.py
@@ -28,7 +28,7 @@ class PartnerDetailView(DetailView):
         return context
 
 
-class PartnerCreateView(UserPassesTestMixin, CreateView):
+class PartnerCreateUpdateMixin(UserPassesTestMixin):
     model = Partner
     template_name = "partner/create_or_update.html"
     form_class = PartnerForm
@@ -36,11 +36,13 @@ class PartnerCreateView(UserPassesTestMixin, CreateView):
     def test_func(self):
         return self.request.user.is_superuser
 
+    def get_success_url(self):
+        return reverse("partner:detail", kwargs={"pk": self.object.pk, "slug": self.object.slug})
+
+
+class PartnerCreateView(PartnerCreateUpdateMixin, CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["title"] = "Créer une nouvelle page partenaire"
         context["back_url"] = reverse("partner:list")
         return context
-
-    def get_success_url(self):
-        return reverse("partner:detail", kwargs={"pk": self.object.pk, "slug": self.object.slug})

--- a/lacommunaute/partner/views.py
+++ b/lacommunaute/partner/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.urls import reverse
-from django.views.generic import CreateView, DetailView, ListView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 from lacommunaute.forum.models import Forum
 from lacommunaute.partner.forms import PartnerForm
@@ -45,4 +45,12 @@ class PartnerCreateView(PartnerCreateUpdateMixin, CreateView):
         context = super().get_context_data(**kwargs)
         context["title"] = "Créer une nouvelle page partenaire"
         context["back_url"] = reverse("partner:list")
+        return context
+
+
+class PartnerUpdateView(PartnerCreateUpdateMixin, UpdateView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["title"] = f"Modifier la page {self.object.name}"
+        context["back_url"] = reverse("partner:detail", kwargs={"pk": self.object.pk, "slug": self.object.slug})
         return context

--- a/lacommunaute/templates/partner/create_or_update.html
+++ b/lacommunaute/templates/partner/create_or_update.html
@@ -1,0 +1,16 @@
+{% extends "board_base.html" %}
+{% block sub_title %}
+    {{ title }}
+{% endblock sub_title %}
+{% block content %}
+    <div class="row">
+        <div class="col-12">
+            <div class="card post-edit">
+                <div class="card-header">
+                    <h3 class="m-0 h4 card-title">{{ title }}</h3>
+                </div>
+                <div class="card-body">{% include "partner/partials/partner_form.html" %}</div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/lacommunaute/templates/partner/detail.html
+++ b/lacommunaute/templates/partner/detail.html
@@ -19,7 +19,7 @@
                         <h1 class="mb-0">{{ partner.name }}</h1>
                     </div>
                     {% if user.is_superuser %}
-                        <a href="{% url 'admin:partner_partner_change' partner.pk %}"><small>Mettre à jour</small></a>
+                        <a href="{% url 'partner:update' partner.slug partner.pk %}"><small>Mettre à jour</small></a>
                     {% endif %}
                     <h2 class="mt-3">{{ partner.short_description }}</h2>
                 </div>

--- a/lacommunaute/templates/partner/list.html
+++ b/lacommunaute/templates/partner/list.html
@@ -56,4 +56,15 @@
             </div>
         </div>
     </section>
+    {% if user.is_superuser %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="s-section__col col-12">
+                        <a href="{% url 'partner:create' %}" aria-label="Ajouter un nouveau partenaire" role="button" class="btn btn-outline-primary">Ajouter un nouveau partenaire</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
 {% endblock content %}

--- a/lacommunaute/templates/partner/partials/partner_form.html
+++ b/lacommunaute/templates/partner/partials/partner_form.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+<form method="post" action="." class="form" enctype="multipart/form-data" novalidate>
+    {% csrf_token %}
+    {% for error in post_form.non_field_errors %}
+        <div class="alert alert-danger">
+            <i class="icon-exclamation-sign"></i> {{ error }}
+        </div>
+    {% endfor %}
+    {% include "partials/form_field.html" with field=form.name %}
+    {% include "partials/form_field.html" with field=form.short_description %}
+    {% include "partials/form_field.html" with field=form.description %}
+    {% include "partials/form_field.html" with field=form.logo %}
+    {% include "partials/form_field.html" with field=form.url %}
+    <hr class="mb-5">
+    <div class="form-actions form-row">
+        <div class="form-group col-auto">
+            <input type="submit" class="btn btn-primary" value="{% trans "Submit" %}" />
+            <a href="{{ back_url }}" class="btn btn-outline-warning">{% trans "Cancel" %}</a>
+        </div>
+    </div>
+</form>

--- a/lacommunaute/utils/html.py
+++ b/lacommunaute/utils/html.py
@@ -1,0 +1,14 @@
+import re
+
+
+def wrap_iframe_in_div_tag(text):
+    # iframe tags must be wrapped in a div tag to be displayed correctly
+    # add div tag if not present
+
+    iframe_regex = r"((<div>)?<iframe.*?</iframe>(</div>)?)"
+
+    for match, starts_with, ends_with in re.findall(iframe_regex, text, re.DOTALL):
+        if not starts_with and not ends_with:
+            text = text.replace(match, f"<div>{match}</div>")
+
+    return text

--- a/lacommunaute/utils/html.py
+++ b/lacommunaute/utils/html.py
@@ -5,7 +5,7 @@ def wrap_iframe_in_div_tag(text):
     # iframe tags must be wrapped in a div tag to be displayed correctly
     # add div tag if not present
 
-    iframe_regex = r"((<div>)?<iframe.*?</iframe>(</div>)?)"
+    iframe_regex = r"((<div>)?<iframe[^>]*>.*?<\/iframe>(<\/div>)?)"
 
     for match, starts_with, ends_with in re.findall(iframe_regex, text, re.DOTALL):
         if not starts_with and not ends_with:

--- a/lacommunaute/utils/html.py
+++ b/lacommunaute/utils/html.py
@@ -2,13 +2,15 @@ import re
 
 
 def wrap_iframe_in_div_tag(text):
-    # iframe tags must be wrapped in a div tag to be displayed correctly
-    # add div tag if not present
+    """
+    given a markdown text, wrap all iframe tags in a div tag
+    this is required for iframes to be displayed correctly
+    """
 
-    iframe_regex = r"((<div>)?<iframe[^>]*>.*?<\/iframe>(<\/div>)?)"
+    iframe_regex = r"((<div>)?(<iframe[^>]*><\/iframe>)(<\/div>)?)"
 
-    for match, starts_with, ends_with in re.findall(iframe_regex, text, re.DOTALL):
-        if not starts_with and not ends_with:
-            text = text.replace(match, f"<div>{match}</div>")
+    for match, starts_with, iframe, ends_with in re.findall(iframe_regex, text):
+        if not (starts_with and ends_with):
+            text = text.replace(match, f"<div>{iframe}</div>")
 
     return text

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -711,17 +711,26 @@ class TestTheLastSunday:
 
 
 class TestWrapIframeInDiv:
-    def test_wrap_iframe_in_div_tag(self):
-        inputs = [
-            "<iframe src='xxx'></iframe>",
-            "<div><iframe src='yyy'></iframe></div>",
-            "<div><iframe src='zzz'></iframe>",
-            "<iframe src='www'></iframe></div>",
-        ]
-        outputs = [
-            "<div><iframe src='xxx'></iframe></div>",
-            "<div><iframe src='yyy'></iframe></div>",
-            "<div><iframe src='zzz'></iframe>",
-            "<iframe src='www'></iframe></div>",
-        ]
-        assert wrap_iframe_in_div_tag(" ".join(inputs)) == " ".join(outputs)
+    @pytest.mark.parametrize(
+        "input,output",
+        [
+            ("<iframe src='xxx'></iframe>", "<div><iframe src='xxx'></iframe></div>"),
+            (
+                "markdown text <iframe src='xxx'></iframe> markdown text",
+                "markdown text <div><iframe src='xxx'></iframe></div> markdown text",
+            ),
+            ("<div><iframe src='xxx'></iframe></div>", "<div><iframe src='xxx'></iframe></div>"),
+            ("<div><iframe src='xxx'></iframe> text", "<div><iframe src='xxx'></iframe></div> text"),
+            ("<iframe src='xxx'></iframe></div>", "<div><iframe src='xxx'></iframe></div>"),
+            (
+                "<iframe src='xxx'></iframe><iframe src='yyy'></iframe>",
+                "<div><iframe src='xxx'></iframe></div><div><iframe src='yyy'></iframe></div>",
+            ),
+            (
+                "<div><iframe src='xxx'></iframe><iframe src='yyy'></iframe></div>",
+                "<div><iframe src='xxx'></iframe></div><div><iframe src='yyy'></iframe></div>",
+            ),
+        ],
+    )
+    def test_wrap_iframe_in_div_tag(self, input, output):
+        assert wrap_iframe_in_div_tag(input) == output

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -24,6 +24,7 @@ from lacommunaute.forum_file.models import PublicFile
 from lacommunaute.stats.models import ForumStat
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.utils.date import get_last_sunday
+from lacommunaute.utils.html import wrap_iframe_in_div_tag
 from lacommunaute.utils.math import percent
 from lacommunaute.utils.matomo import (
     collect_forum_stats_from_matomo_api,
@@ -707,3 +708,20 @@ class TestTheLastSunday:
     )
     def test_the_last_sunday(self, day, expected_sunday):
         assert get_last_sunday(datetime(2024, 5, day)) == expected_sunday
+
+
+class TestWrapIframeInDiv:
+    def test_wrap_iframe_in_div_tag(self):
+        inputs = [
+            "<iframe src='xxx'></iframe>",
+            "<div><iframe src='yyy'></iframe></div>",
+            "<div><iframe src='zzz'></iframe>",
+            "<iframe src='www'></iframe></div>",
+        ]
+        outputs = [
+            "<div><iframe src='xxx'></iframe></div>",
+            "<div><iframe src='yyy'></iframe></div>",
+            "<div><iframe src='zzz'></iframe>",
+            "<iframe src='www'></iframe></div>",
+        ]
+        assert wrap_iframe_in_div_tag(" ".join(inputs)) == " ".join(outputs)


### PR DESCRIPTION
## Description

🎸 Permettre l'ajout et la mise à jour des `Partner` depuis la page `partner:list`
🎸 Accès limité aux super-utilisateurs

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 factorisation de la méthode `wrap_iframe_in_div_tag`
🦺 mixin et template communs pour `PartnerCreateView` et `PartnerUpdateView`


### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/9b2937cb-e1bd-454b-a5bc-cb85fddbae76)

![image](https://github.com/user-attachments/assets/08be764f-9aac-4c6e-aab1-e591a93e2197)

