### PR TITLE
refactor(documentation): partie 4, ajout des vues du modèle `category` de l'app `documentation`

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -5,6 +5,7 @@ from django.contrib.flatpages import views
 from django.urls import include, path, re_path
 from machina.core.loading import get_class
 
+from lacommunaute.documentation import urls as documentation_urls
 from lacommunaute.event import urls as event_urls
 from lacommunaute.forum import urls as forum_extension_urls
 from lacommunaute.forum_conversation import urls as forum_conversation_extension_urls
@@ -30,6 +31,7 @@ urlpatterns = [
     path("inclusion_connect/", include(inclusion_connect_urls)),
     # www.
     path("", include(pages_urls)),
+    path("documentation/", include(documentation_urls)),
     path("members/", include(forum_member_urls)),
     path("", include(forum_conversation_extension_urls)),
     path("", include(forum_extension_urls)),

--- a/lacommunaute/documentation/models.py
+++ b/lacommunaute/documentation/models.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
+from django.urls import reverse
 from taggit.managers import TaggableManager
 
 from lacommunaute.forum_upvote.models import UpVote
@@ -15,6 +16,9 @@ class Category(Publication):
 
     def __str__(self):
         return f"{self.name}"
+
+    def get_absolute_url(self):
+        return reverse("documentation:category_detail", kwargs={"pk": self.pk, "slug": self.slug})
 
 
 class Document(Publication):

--- a/lacommunaute/documentation/models.py
+++ b/lacommunaute/documentation/models.py
@@ -20,6 +20,9 @@ class Category(Publication):
     def get_absolute_url(self):
         return reverse("documentation:category_detail", kwargs={"pk": self.pk, "slug": self.slug})
 
+    def get_update_url(self):
+        return reverse("documentation:category_update", kwargs={"pk": self.pk, "slug": self.slug})
+
 
 class Document(Publication):
     category = models.ForeignKey(Category, on_delete=models.CASCADE, related_name="documents")

--- a/lacommunaute/documentation/tests/__snapshots__/tests_category_detail_view.ambr
+++ b/lacommunaute/documentation/tests/__snapshots__/tests_category_detail_view.ambr
@@ -1,0 +1,369 @@
+# serializer version: 1
+# name: test_category_detail_view_with_tagged_documents[None-category_detail_view_without_active_tag][category_detail_view_without_active_tag]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              <li class="breadcrumb-item">
+                  
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  
+              </li>
+              
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Category</h1>
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      
+          <section class="s-section">
+              <div class="s-section__container container">
+                  <div class="s-section__row row">
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Category" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  </div>
+              </div>
+          </section>
+      
+      
+          <section class="s-section">
+              <div class="s-section__container container">
+                  <div class="s-section__row row">
+                      <div class="s-section__col col-12">
+                          <div class="c-box">
+                              <div class="text-center mb-3">Afficher les fiches contenant l'étiquette</div>
+                              <div class="text-center tag-group">
+                                  
+                                      
+                                          <button aria-label="Filtrer par tag1" class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="document" hx-get="#" hx-swap="outerHTML" hx-target="#documents_area" id="filterdocument-tag1">tag1</button>
+                                      
+                                  
+                                      
+                                          <button aria-label="Filtrer par tag2" class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="document" hx-get="#" hx-swap="outerHTML" hx-target="#documents_area" id="filterdocument-tag2">tag2</button>
+                                      
+                                  
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </section>
+      
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="s-section__col col-12">
+                      <div class="row mt-4" id="documents">
+                          
+                              <div class="col-12 col-md-4 mb-3 mb-md-5">
+      <div class="card c-card has-one-link-inside h-100">
+          
+              <div class="card-header card-header-thumbnail rounded">
+                  <img alt="Test Document" class="img-fitcover img-fluid" loading="lazy" src="[img src]"/>
+              </div>
+          
+          <div class="card-body pb-0">
+              <p class="h3 lh-base">Test Document</p>
+              <div>
+                  <span class="tag bg-info-lighter text-info">tag1</span><span class="tag bg-info-lighter text-info">tag2</span>
+              </div>
+              <div class="mt-3">Test short description</div>
+          </div>
+          <div class="card-footer text-end">
+              
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="#">
+                      <span>Consulter la fiche</span>
+                      <i class="ri-arrow-right-line ri-lg"></i>
+                  </a>
+              
+          </div>
+      </div>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_category_detail_view_with_tagged_documents[tag1-category_detail_view_with_active_tag][category_detail_view_with_active_tag]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              <li class="breadcrumb-item">
+                  
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  
+              </li>
+              
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Category</h1>
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      
+          <section class="s-section">
+              <div class="s-section__container container">
+                  <div class="s-section__row row">
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Category" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  </div>
+              </div>
+          </section>
+      
+      
+          <section class="s-section">
+              <div class="s-section__container container">
+                  <div class="s-section__row row">
+                      <div class="s-section__col col-12">
+                          <div class="c-box">
+                              <div class="text-center mb-3">Afficher les fiches contenant l'étiquette</div>
+                              <div class="text-center tag-group">
+                                  
+                                      
+                                          <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="document" hx-get="#" hx-swap="outerHTML" hx-target="#documents_area" id="filterdocument-tag1">
+                                              <i class="ri-close-fill ri-xs"></i>tag1
+                                          </button>
+                                      
+                                  
+                                      
+                                          <button aria-label="Filtrer par tag2" class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="document" hx-get="#" hx-swap="outerHTML" hx-target="#documents_area" id="filterdocument-tag2">tag2</button>
+                                      
+                                  
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </section>
+      
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="s-section__col col-12">
+                      <div class="row mt-4" id="documents">
+                          
+                              <div class="col-12 col-md-4 mb-3 mb-md-5">
+      <div class="card c-card has-one-link-inside h-100">
+          
+              <div class="card-header card-header-thumbnail rounded">
+                  <img alt="Test Document" class="img-fitcover img-fluid" loading="lazy" src="[img src]"/>
+              </div>
+          
+          <div class="card-body pb-0">
+              <p class="h3 lh-base">Test Document</p>
+              <div>
+                  <span class="tag bg-info-lighter text-info">tag1</span><span class="tag bg-info-lighter text-info">tag2</span>
+              </div>
+              <div class="mt-3">Test short description</div>
+          </div>
+          <div class="card-footer text-end">
+              
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="#">
+                      <span>Consulter la fiche</span>
+                      <i class="ri-arrow-right-line ri-lg"></i>
+                  </a>
+              
+          </div>
+      </div>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_category_detail_view_with_tagged_documents[unknowntag-category_detail_view_with_unknown_tag][category_detail_view_with_unknown_tag]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              <li class="breadcrumb-item">
+                  
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  
+              </li>
+              
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Category</h1>
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      
+          <section class="s-section">
+              <div class="s-section__container container">
+                  <div class="s-section__row row">
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Category" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  </div>
+              </div>
+          </section>
+      
+      
+          <section class="s-section">
+              <div class="s-section__container container">
+                  <div class="s-section__row row">
+                      <div class="s-section__col col-12">
+                          <div class="c-box">
+                              <div class="text-center mb-3">Afficher les fiches contenant l'étiquette</div>
+                              <div class="text-center tag-group">
+                                  
+                                      
+                                          <button aria-label="Filtrer par tag1" class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="document" hx-get="#" hx-swap="outerHTML" hx-target="#documents_area" id="filterdocument-tag1">tag1</button>
+                                      
+                                  
+                                      
+                                          <button aria-label="Filtrer par tag2" class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="document" hx-get="#" hx-swap="outerHTML" hx-target="#documents_area" id="filterdocument-tag2">tag2</button>
+                                      
+                                  
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </section>
+      
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="s-section__col col-12">
+                      <div class="row mt-4" id="documents">
+                          
+                              <div class="col-12 col-md-4 mb-3 mb-md-5">
+      <div class="card c-card has-one-link-inside h-100">
+          
+              <div class="card-header card-header-thumbnail rounded">
+                  <img alt="Test Document" class="img-fitcover img-fluid" loading="lazy" src="[img src]"/>
+              </div>
+          
+          <div class="card-body pb-0">
+              <p class="h3 lh-base">Test Document</p>
+              <div>
+                  <span class="tag bg-info-lighter text-info">tag1</span><span class="tag bg-info-lighter text-info">tag2</span>
+              </div>
+              <div class="mt-3">Test short description</div>
+          </div>
+          <div class="card-footer text-end">
+              
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="#">
+                      <span>Consulter la fiche</span>
+                      <i class="ri-arrow-right-line ri-lg"></i>
+                  </a>
+              
+          </div>
+      </div>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---

--- a/lacommunaute/documentation/tests/__snapshots__/tests_category_list_view.ambr
+++ b/lacommunaute/documentation/tests/__snapshots__/tests_category_list_view.ambr
@@ -1,0 +1,147 @@
+# serializer version: 1
+# name: test_category_list_view[objects0-200-category_list_view_is_empty][category_list_view_is_empty]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1>Documentation</h1>
+                      <h2 class="mt-3">
+                          Retrouver les ressources nécessaires pour améliorer ses diagnostics socio-professionnels et ses accompagnements des personnes éloignées de l’emploi
+                      </h2>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  
+              </div>
+          </div>
+      </section>
+      
+  
+              
+          </main>
+  '''
+# ---
+# name: test_category_list_view[objects1-200-category_list_view_with_categories][category_list_view_with_categories]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1>Documentation</h1>
+                      <h2 class="mt-3">
+                          Retrouver les ressources nécessaires pour améliorer ses diagnostics socio-professionnels et ses accompagnements des personnes éloignées de l’emploi
+                      </h2>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  
+                      <div class="col-12 col-md-4 mb-3 mb-md-5">
+      <div class="card c-card has-one-link-inside h-100">
+          
+              <div class="card-header card-header-thumbnail rounded">
+                  <img alt="titre 1" class="img-fitcover img-fluid" loading="lazy" src="[img src]"/>
+              </div>
+          
+          <div class="card-body pb-0">
+              <p class="h3 lh-base">titre 1</p>
+              <div>
+                  
+              </div>
+              <div class="mt-3">short desc 1</div>
+          </div>
+          <div class="card-footer text-end">
+              
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="#">
+                      <span>Consulter les fiches du thème</span>
+                      <i class="ri-arrow-right-line ri-lg"></i>
+                  </a>
+              
+          </div>
+      </div>
+  </div>
+  
+                  
+                      <div class="col-12 col-md-4 mb-3 mb-md-5">
+      <div class="card c-card has-one-link-inside h-100">
+          
+              <div class="card-header card-header-thumbnail rounded">
+                  <img alt="titre 2" class="img-fitcover img-fluid" loading="lazy" src="[img src]"/>
+              </div>
+          
+          <div class="card-body pb-0">
+              <p class="h3 lh-base">titre 2</p>
+              <div>
+                  
+              </div>
+              <div class="mt-3">short desc 2</div>
+          </div>
+          <div class="card-footer text-end">
+              
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="#">
+                      <span>Consulter les fiches du thème</span>
+                      <i class="ri-arrow-right-line ri-lg"></i>
+                  </a>
+              
+          </div>
+      </div>
+  </div>
+  
+                  
+                      <div class="col-12 col-md-4 mb-3 mb-md-5">
+      <div class="card c-card has-one-link-inside h-100">
+          
+              <div class="card-header card-header-thumbnail rounded">
+                  <img alt="titre 3" class="img-fitcover img-fluid" loading="lazy" src="[img src]"/>
+              </div>
+          
+          <div class="card-body pb-0">
+              <p class="h3 lh-base">titre 3</p>
+              <div>
+                  
+              </div>
+              <div class="mt-3">short desc 3</div>
+          </div>
+          <div class="card-footer text-end">
+              
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="#">
+                      <span>Consulter les fiches du thème</span>
+                      <i class="ri-arrow-right-line ri-lg"></i>
+                  </a>
+              
+          </div>
+      </div>
+  </div>
+  
+                  
+              </div>
+          </div>
+      </section>
+      
+  
+              
+          </main>
+  '''
+# ---

--- a/lacommunaute/documentation/tests/__snapshots__/tests_category_list_view.ambr
+++ b/lacommunaute/documentation/tests/__snapshots__/tests_category_list_view.ambr
@@ -74,7 +74,7 @@
           </div>
           <div class="card-footer text-end">
               
-                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="#">
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="/documentation/titre-1-[PK of Category]/">
                       <span>Consulter les fiches du thème</span>
                       <i class="ri-arrow-right-line ri-lg"></i>
                   </a>
@@ -100,7 +100,7 @@
           </div>
           <div class="card-footer text-end">
               
-                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="#">
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="/documentation/titre-2-[PK of Category]/">
                       <span>Consulter les fiches du thème</span>
                       <i class="ri-arrow-right-line ri-lg"></i>
                   </a>
@@ -126,7 +126,7 @@
           </div>
           <div class="card-footer text-end">
               
-                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="#">
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="category" href="/documentation/titre-3-[PK of Category]/">
                       <span>Consulter les fiches du thème</span>
                       <i class="ri-arrow-right-line ri-lg"></i>
                   </a>

--- a/lacommunaute/documentation/tests/tests_category_create_view.py
+++ b/lacommunaute/documentation/tests/tests_category_create_view.py
@@ -1,0 +1,70 @@
+import pytest  # noqa
+
+from django.urls import reverse
+
+from lacommunaute.documentation.models import Category
+from lacommunaute.users.factories import UserFactory
+
+
+@pytest.fixture(name="url")
+def fixture_url():
+    return reverse("documentation:category_create")
+
+
+@pytest.fixture(name="superuser")
+def fixture_superuser(db):
+    return UserFactory(is_superuser=True)
+
+
+@pytest.mark.parametrize(
+    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
+)
+def test_user_passes_test_mixin(client, db, url, user, status_code):
+    if user:
+        client.force_login(user())
+    response = client.get(url)
+    assert response.status_code == status_code
+
+
+@pytest.fixture(name="expected_context")
+def fixture_expected_context():
+    return {
+        "title": "Créer une nouvelle catégorie",
+        "back_url": reverse("documentation:category_list"),
+    }
+
+
+def test_view(client, db, url, superuser, expected_context):
+    client.force_login(superuser)
+    response = client.get(url)
+    assert response.status_code == 200
+    assert {k: response.context[k] for k in expected_context.keys()} == expected_context
+    assert response.context["form"].fields.keys() == {"name", "short_description", "description", "image"}
+
+
+@pytest.fixture(name="post_data")
+def fixture_post_data():
+    return {
+        "name": "Test Name",
+        "short_description": "Test Short Description",
+        "description": "## Test Description\n- with markdown",
+    }
+
+
+@pytest.fixture(name="expected_values")
+def fixture_expected_values():
+    return {
+        "name": "Test Name",
+        "short_description": "Test Short Description",
+        "_description_rendered": "<h2>Test Description</h2>\n\n<ul>\n<li>with markdown</li>\n</ul>",
+        "slug": "test-name",
+    }
+
+
+def test_create_category(client, db, url, superuser, post_data, expected_values):
+    client.force_login(superuser)
+    response = client.post(url, data=post_data)
+    assert response.status_code == 302
+
+    category = Category.objects.get()
+    assert {k: getattr(category, k) for k in expected_values.keys()} == expected_values

--- a/lacommunaute/documentation/tests/tests_category_detail_view.py
+++ b/lacommunaute/documentation/tests/tests_category_detail_view.py
@@ -1,0 +1,34 @@
+import pytest  # noqa
+
+from django.urls import reverse
+
+from lacommunaute.documentation.factories import CategoryFactory, DocumentFactory
+from lacommunaute.utils.testing import parse_response_to_soup
+
+
+@pytest.fixture(name="category")
+def fixture_category():
+    return CategoryFactory(for_snapshot=True)
+
+
+@pytest.fixture(name="url")
+def fixture_url(category):
+    return reverse("documentation:category_detail", kwargs={"pk": category.pk, "slug": category.slug})
+
+
+@pytest.mark.parametrize(
+    "active_tag, snapshot_name",
+    [
+        ("tag1", "category_detail_view_with_active_tag"),
+        (None, "category_detail_view_without_active_tag"),
+        ("unknowntag", "category_detail_view_with_unknown_tag"),
+    ],
+)
+def test_category_detail_view_with_tagged_documents(client, db, url, category, active_tag, snapshot_name, snapshot):
+    DocumentFactory(category=category, with_tags=["tag1", "tag2"], for_snapshot=True)
+    if active_tag:
+        url = f"{url}?tag={active_tag}"
+    response = client.get(url)
+    assert response.status_code == 200
+    content = parse_response_to_soup(response, selector="main", replace_img_src=True, replace_in_href=[category])
+    assert str(content) == snapshot(name=snapshot_name)

--- a/lacommunaute/documentation/tests/tests_category_detail_view.py
+++ b/lacommunaute/documentation/tests/tests_category_detail_view.py
@@ -1,7 +1,5 @@
 import pytest  # noqa
 
-from django.urls import reverse
-
 from lacommunaute.documentation.factories import CategoryFactory, DocumentFactory
 from lacommunaute.utils.testing import parse_response_to_soup
 
@@ -9,11 +7,6 @@ from lacommunaute.utils.testing import parse_response_to_soup
 @pytest.fixture(name="category")
 def fixture_category():
     return CategoryFactory(for_snapshot=True)
-
-
-@pytest.fixture(name="url")
-def fixture_url(category):
-    return reverse("documentation:category_detail", kwargs={"pk": category.pk, "slug": category.slug})
 
 
 @pytest.mark.parametrize(
@@ -24,10 +17,9 @@ def fixture_url(category):
         ("unknowntag", "category_detail_view_with_unknown_tag"),
     ],
 )
-def test_category_detail_view_with_tagged_documents(client, db, url, category, active_tag, snapshot_name, snapshot):
+def test_category_detail_view_with_tagged_documents(client, db, category, active_tag, snapshot_name, snapshot):
     DocumentFactory(category=category, with_tags=["tag1", "tag2"], for_snapshot=True)
-    if active_tag:
-        url = f"{url}?tag={active_tag}"
+    url = f"{category.get_absolute_url()}?tag={active_tag}" if active_tag else category.get_absolute_url()
     response = client.get(url)
     assert response.status_code == 200
     content = parse_response_to_soup(response, selector="main", replace_img_src=True, replace_in_href=[category])

--- a/lacommunaute/documentation/tests/tests_category_list_view.py
+++ b/lacommunaute/documentation/tests/tests_category_list_view.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from lacommunaute.documentation.factories import CategoryFactory
 from lacommunaute.utils.testing import parse_response_to_soup
+from lacommunaute.users.factories import UserFactory
 
 
 @pytest.fixture(name="url")
@@ -30,3 +31,15 @@ def test_category_list_view(client, db, url, objects, status_code, snapshot_name
     assert response.status_code == status_code
     content = parse_response_to_soup(response, selector="main", replace_img_src=True, replace_in_href=categories)
     assert str(content) == snapshot(name=snapshot_name)
+
+
+@pytest.mark.parametrize(
+    "user,link_is_visible",
+    [(None, False), (lambda: UserFactory(), False), (lambda: UserFactory(is_superuser=True), True)],
+)
+def test_link_to_createview(client, db, url, user, link_is_visible):
+    if user:
+        client.force_login(user())
+    response = client.get(url)
+    assert response.status_code == 200
+    assert bool(reverse("documentation:category_create") in response.content.decode()) == link_is_visible

--- a/lacommunaute/documentation/tests/tests_category_list_view.py
+++ b/lacommunaute/documentation/tests/tests_category_list_view.py
@@ -1,0 +1,32 @@
+import pytest  # noqa
+from django.urls import reverse
+
+from lacommunaute.documentation.factories import CategoryFactory
+from lacommunaute.utils.testing import parse_response_to_soup
+
+
+@pytest.fixture(name="url")
+def fixture_url():
+    return reverse("documentation:category_list")
+
+
+@pytest.mark.parametrize(
+    "objects,status_code,snapshot_name",
+    [
+        ([], 200, "category_list_view_is_empty"),
+        (
+            [(f"titre {i}", f"short desc {i}", f"desc {i}") for i in range(1, 4)],
+            200,
+            "category_list_view_with_categories",
+        ),
+    ],
+)
+def test_category_list_view(client, db, url, objects, status_code, snapshot_name, snapshot):
+    categories = [
+        CategoryFactory(name=titre, short_description=short_desc, description=desc)
+        for titre, short_desc, desc in objects
+    ]
+    response = client.get(url)
+    assert response.status_code == status_code
+    content = parse_response_to_soup(response, selector="main", replace_img_src=True, replace_in_href=categories)
+    assert str(content) == snapshot(name=snapshot_name)

--- a/lacommunaute/documentation/tests/tests_category_update_view.py
+++ b/lacommunaute/documentation/tests/tests_category_update_view.py
@@ -12,11 +12,6 @@ def fixture_category(db):
     return CategoryFactory(for_snapshot=True)
 
 
-@pytest.fixture(name="url")
-def fixture_url(category):
-    return reverse("documentation:category_update", kwargs={"slug": category.slug, "pk": category.pk})
-
-
 @pytest.fixture(name="superuser")
 def fixture_superuser(db):
     return UserFactory(is_superuser=True)
@@ -25,10 +20,10 @@ def fixture_superuser(db):
 @pytest.mark.parametrize(
     "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
 )
-def test_user_passes_test_mixin(client, db, url, user, status_code):
+def test_user_passes_test_mixin(client, db, category, user, status_code):
     if user:
         client.force_login(user())
-    response = client.get(url)
+    response = client.get(category.get_update_url())
     assert response.status_code == status_code
 
 
@@ -40,9 +35,9 @@ def fixture_expected_context(category):
     }
 
 
-def test_view(client, db, url, superuser, expected_context):
+def test_view(client, db, category, superuser, expected_context):
     client.force_login(superuser)
-    response = client.get(url)
+    response = client.get(category.get_update_url())
     assert response.status_code == 200
     assert {k: response.context[k] for k in expected_context.keys()} == expected_context
     assert response.context["form"].fields.keys() == {"name", "short_description", "description", "image"}
@@ -67,9 +62,9 @@ def fixture_expected_values(post_data):
     }
 
 
-def test_update(client, db, url, superuser, post_data, expected_values):
+def test_update(client, db, category, superuser, post_data, expected_values):
     client.force_login(superuser)
-    response = client.post(url, post_data)
+    response = client.post(category.get_update_url(), post_data)
     assert response.status_code == 302
     category = Category.objects.get(slug=expected_values["slug"])
     assert {k: getattr(category, k) for k in expected_values.keys()} == expected_values

--- a/lacommunaute/documentation/tests/tests_category_update_view.py
+++ b/lacommunaute/documentation/tests/tests_category_update_view.py
@@ -1,0 +1,75 @@
+import pytest  # noqa
+
+from django.urls import reverse
+
+from lacommunaute.documentation.factories import CategoryFactory
+from lacommunaute.documentation.models import Category
+from lacommunaute.users.factories import UserFactory
+
+
+@pytest.fixture(name="category")
+def fixture_category(db):
+    return CategoryFactory(for_snapshot=True)
+
+
+@pytest.fixture(name="url")
+def fixture_url(category):
+    return reverse("documentation:category_update", kwargs={"slug": category.slug, "pk": category.pk})
+
+
+@pytest.fixture(name="superuser")
+def fixture_superuser(db):
+    return UserFactory(is_superuser=True)
+
+
+@pytest.mark.parametrize(
+    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
+)
+def test_user_passes_test_mixin(client, db, url, user, status_code):
+    if user:
+        client.force_login(user())
+    response = client.get(url)
+    assert response.status_code == status_code
+
+
+@pytest.fixture(name="expected_context")
+def fixture_expected_context(category):
+    return {
+        "title": f"Modifier la catégorie {category.name}",
+        "back_url": reverse("documentation:category_detail", kwargs={"slug": category.slug, "pk": category.pk}),
+    }
+
+
+def test_view(client, db, url, superuser, expected_context):
+    client.force_login(superuser)
+    response = client.get(url)
+    assert response.status_code == 200
+    assert {k: response.context[k] for k in expected_context.keys()} == expected_context
+    assert response.context["form"].fields.keys() == {"name", "short_description", "description", "image"}
+
+
+@pytest.fixture(name="post_data")
+def fixture_post_data():
+    return {
+        "name": "New Name",
+        "short_description": "New Short Description",
+        "description": "### New Description",
+    }
+
+
+@pytest.fixture(name="expected_values")
+def fixture_expected_values(post_data):
+    return {
+        "name": post_data["name"],
+        "short_description": post_data["short_description"],
+        "_description_rendered": "<h3>New Description</h3>",
+        "slug": "new-name",
+    }
+
+
+def test_update(client, db, url, superuser, post_data, expected_values):
+    client.force_login(superuser)
+    response = client.post(url, post_data)
+    assert response.status_code == 302
+    category = Category.objects.get(slug=expected_values["slug"])
+    assert {k: getattr(category, k) for k in expected_values.keys()} == expected_values

--- a/lacommunaute/documentation/tests/tests_models.py
+++ b/lacommunaute/documentation/tests/tests_models.py
@@ -17,6 +17,10 @@ class TestCategory:
         category = CategoryFactory()
         assert category.get_absolute_url() == f"/documentation/{category.slug}-{category.pk}/"
 
+    def test_get_update_url(self, db):
+        category = CategoryFactory()
+        assert category.get_update_url() == f"/documentation/{category.slug}-{category.pk}/update/"
+
 
 class TestDocument:
     def test_slug(self, db):

--- a/lacommunaute/documentation/tests/tests_models.py
+++ b/lacommunaute/documentation/tests/tests_models.py
@@ -13,6 +13,10 @@ class TestCategory:
         with pytest.raises(IntegrityError):
             CategoryFactory(for_snapshot=True)
 
+    def test_get_absolute_url(self, db):
+        category = CategoryFactory()
+        assert category.get_absolute_url() == f"/documentation/{category.slug}-{category.pk}/"
+
 
 class TestDocument:
     def test_slug(self, db):

--- a/lacommunaute/documentation/urls.py
+++ b/lacommunaute/documentation/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from lacommunaute.documentation.views import CategoryDetailView, CategoryListView
+from lacommunaute.documentation.views import CategoryCreateView, CategoryDetailView, CategoryListView
 
 
 app_name = "documentation"
@@ -9,4 +9,5 @@ app_name = "documentation"
 urlpatterns = [
     path("", CategoryListView.as_view(), name="category_list"),
     path("<str:slug>-<int:pk>/", CategoryDetailView.as_view(), name="category_detail"),
+    path("category/create/", CategoryCreateView.as_view(), name="category_create"),
 ]

--- a/lacommunaute/documentation/urls.py
+++ b/lacommunaute/documentation/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from lacommunaute.documentation.views import CategoryListView
+from lacommunaute.documentation.views import CategoryDetailView, CategoryListView
 
 
 app_name = "documentation"
@@ -8,4 +8,5 @@ app_name = "documentation"
 
 urlpatterns = [
     path("", CategoryListView.as_view(), name="category_list"),
+    path("<str:slug>-<int:pk>/", CategoryDetailView.as_view(), name="category_detail"),
 ]

--- a/lacommunaute/documentation/urls.py
+++ b/lacommunaute/documentation/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from lacommunaute.documentation.views import CategoryCreateView, CategoryDetailView, CategoryListView
+from lacommunaute.documentation.views import (
+    CategoryCreateView,
+    CategoryDetailView,
+    CategoryListView,
+    CategoryUpdateView,
+)
 
 
 app_name = "documentation"
@@ -10,4 +15,5 @@ urlpatterns = [
     path("", CategoryListView.as_view(), name="category_list"),
     path("<str:slug>-<int:pk>/", CategoryDetailView.as_view(), name="category_detail"),
     path("category/create/", CategoryCreateView.as_view(), name="category_create"),
+    path("<str:slug>-<int:pk>/update/", CategoryUpdateView.as_view(), name="category_update"),
 ]

--- a/lacommunaute/documentation/urls.py
+++ b/lacommunaute/documentation/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from lacommunaute.documentation.views import CategoryListView
+
+
+app_name = "documentation"
+
+
+urlpatterns = [
+    path("", CategoryListView.as_view(), name="category_list"),
+]

--- a/lacommunaute/documentation/views.py
+++ b/lacommunaute/documentation/views.py
@@ -1,6 +1,8 @@
-from django.views.generic import ListView
+from django.contrib.contenttypes.models import ContentType
+from django.views.generic import DetailView, ListView
+from taggit.models import Tag
 
-from lacommunaute.documentation.models import Category
+from lacommunaute.documentation.models import Category, Document
 
 
 class CategoryListView(ListView):
@@ -8,3 +10,24 @@ class CategoryListView(ListView):
     template_name = "documentation/category_list.html"
     context_object_name = "categories"
     paginate_by = 20 * 3
+
+
+class CategoryDetailView(DetailView):
+    model = Category
+    template_name = "documentation/category_detail.html"
+    context_object_name = "category"
+
+    def get_tags_of_documents(self):
+        return Tag.objects.filter(
+            taggit_taggeditem_items__content_type=ContentType.objects.get_for_model(Document),
+            taggit_taggeditem_items__object_id__in=self.object.documents.all().values_list("id", flat=True),
+        ).distinct()
+
+    def get_queryset(self):
+        return super().get_queryset().prefetch_related("documents__tags")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["tags"] = self.get_tags_of_documents()
+        context["active_tag_slug"] = self.request.GET.get("tag") or None
+        return context

--- a/lacommunaute/documentation/views.py
+++ b/lacommunaute/documentation/views.py
@@ -1,0 +1,10 @@
+from django.views.generic import ListView
+
+from lacommunaute.documentation.models import Category
+
+
+class CategoryListView(ListView):
+    model = Category
+    template_name = "documentation/category_list.html"
+    context_object_name = "categories"
+    paginate_by = 20 * 3

--- a/lacommunaute/documentation/views.py
+++ b/lacommunaute/documentation/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth.mixins import UserPassesTestMixin
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.views.generic import DetailView, ListView
-from django.views.generic.edit import CreateView
+from django.views.generic.edit import CreateView, UpdateView
 from taggit.models import Tag
 
 from lacommunaute.documentation.models import Category, Document
@@ -55,5 +55,14 @@ class CategoryCreateView(CategoryCreateUpdateMixin, CreateView):
         additionnal_context = {
             "title": "Créer une nouvelle catégorie",
             "back_url": reverse("documentation:category_list"),
+        }
+        return super().get_context_data(**kwargs) | additionnal_context
+
+
+class CategoryUpdateView(CategoryCreateUpdateMixin, UpdateView):
+    def get_context_data(self, **kwargs):
+        additionnal_context = {
+            "title": f"Modifier la catégorie {self.object.name}",
+            "back_url": self.object.get_absolute_url(),
         }
         return super().get_context_data(**kwargs) | additionnal_context

--- a/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
@@ -6,7 +6,7 @@
               <li class="breadcrumb-item">Retourner vers</li>
               <li class="breadcrumb-item">
                   
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="#">Documentation</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
                   
               </li>
               
@@ -22,7 +22,7 @@
               <li class="breadcrumb-item">Retourner vers</li>
               <li class="breadcrumb-item">
                   
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="#">Documentation</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
                   
               </li>
               
@@ -60,7 +60,7 @@
               <li class="breadcrumb-item">Retourner vers</li>
               <li class="breadcrumb-item">
                   
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="#">Documentation</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
                   
               </li>
               
@@ -176,7 +176,7 @@
               <li class="breadcrumb-item">Retourner vers</li>
               <li class="breadcrumb-item">
                   
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="#">Documentation</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
                   
               </li>
               

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -329,7 +329,7 @@
               <li class="breadcrumb-item">Retourner vers</li>
               <li class="breadcrumb-item">
                   
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="#">Documentation</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
                   
               </li>
               

--- a/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
+++ b/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
@@ -13,7 +13,7 @@
                                   <a href="/topics/">Espace d'échanges</a>
                               </li>
                               <li>
-                                  <a href="#">Documentation</a>
+                                  <a href="/documentation/">Documentation</a>
                               </li>
                               <li>
                                   <a href="/calendar/events/">Évènements</a>
@@ -196,7 +196,7 @@
                                   <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics" href="/topics/">Espace d'échanges</a>
                               </li>
                               <li>
-                                  <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_header" href="">Documentation</a>
+                                  <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_header" href="/documentation/">Documentation</a>
                               </li>
                               <li>
                                   <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="events" href="/calendar/events/">Évènements</a>
@@ -242,7 +242,7 @@
                           <a class="nav-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics" href="/topics/">Espace d'échanges</a>
                       </li>
                       <li class="nav-item">
-                          <a class="nav-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_header" href="">Documentation</a>
+                          <a class="nav-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_header" href="/documentation/">Documentation</a>
                       </li>
                       <li>
                           <a class="nav-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="events" href="/calendar/events/">Évènements</a>

--- a/lacommunaute/templates/404.html
+++ b/lacommunaute/templates/404.html
@@ -15,7 +15,7 @@
                                 <a href="{% url 'forum_conversation_extension:topics' %}">Espace d'échanges</a>
                             </li>
                             <li>
-                                <a href="#">Documentation</a>
+                                <a href="{% url 'documentation:category_list' %}">Documentation</a>
                             </li>
                             <li>
                                 <a href="{% url 'search:index' %}">Recherche</a>

--- a/lacommunaute/templates/documentation/category_create_or_update.html
+++ b/lacommunaute/templates/documentation/category_create_or_update.html
@@ -1,0 +1,37 @@
+{% extends "board_base.html" %}
+{% load i18n %}
+{% block sub_title %}
+    {{ title }}
+{% endblock sub_title %}
+{% block content %}
+    <div class="row">
+        <div class="col-12">
+            <div class="card post-edit">
+                <div class="card-header">
+                    <h3 class="m-0 h4 card-title">{{ title }}</h3>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="." class="form" enctype="multipart/form-data" novalidate>
+                        {% csrf_token %}
+                        {% for error in post_form.non_field_errors %}
+                            <div class="alert alert-danger">
+                                <i class="icon-exclamation-sign"></i> {{ error }}
+                            </div>
+                        {% endfor %}
+                        {% include "partials/form_field.html" with field=form.name %}
+                        {% include "partials/form_field.html" with field=form.short_description %}
+                        {% include "partials/form_field.html" with field=form.description %}
+                        {% include "partials/form_field.html" with field=form.image %}
+                        <hr class="mb-5">
+                        <div class="form-actions form-row">
+                            <div class="form-group col-auto">
+                                <input type="submit" class="btn btn-primary" value="{% trans "Submit" %}" />
+                                <a href="{{ back_url }}" class="btn btn-outline-warning">{% trans "Cancel" %}</a>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/lacommunaute/templates/documentation/category_detail.html
+++ b/lacommunaute/templates/documentation/category_detail.html
@@ -1,0 +1,75 @@
+{% extends "layouts/base.html" %}
+{% load i18n %}
+{% block title %}{{ category.name }}{{ block.super }}{% endblock %}
+{% block meta_description %}
+    {{ category.short_description }}
+{% endblock meta_description %}
+{% block breadcrumb %}
+    {% include "partials/breadcrumb.html" %}
+{% endblock %}
+{% block content %}
+    {% include 'documentation/partials/title_and_shortdesc.html' with obj=category user=user only %}
+    {% if category.description %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">{% include 'documentation/partials/image_and_desc.html' with obj=category only %}</div>
+            </div>
+        </section>
+    {% endif %}
+    {% if tags %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="s-section__col col-12">
+                        <div class="c-box">
+                            <div class="text-center mb-3">Afficher les fiches contenant l'étiquette</div>
+                            <div class="text-center tag-group">
+                                {% for tag in tags %}
+                                    {% if tag.slug == active_tag_slug %}
+                                        <button id="filterdocument-{{ tag.slug }}"
+                                                hx-target="#documents_area"
+                                                hx-swap="outerHTML"
+                                                hx-get="#"
+                                                class="tag bg-info text-white matomo-event"
+                                                data-bs-toggle="tooltip"
+                                                data-bs-placement="top"
+                                                data-bs-title="Supprimer ce filtre"
+                                                aria-label="Supprimer ce filtre"
+                                                data-matomo-category="engagement"
+                                                data-matomo-action="unfilter"
+                                                data-matomo-option="document">
+                                            <i class="ri-close-fill ri-xs"></i>{{ tag.name }}
+                                        </button>
+                                    {% else %}
+                                        <button id="filterdocument-{{ tag.slug }}"
+                                                hx-target="#documents_area"
+                                                hx-swap="outerHTML"
+                                                hx-get="#"
+                                                class="tag bg-info-lighter text-info matomo-event"
+                                                data-matomo-category="engagement"
+                                                aria-label="Filtrer par {{ tag.name }}"
+                                                data-matomo-action="filter"
+                                                data-matomo-option="document">{{ tag.name }}</button>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    <div class="row mt-4" id="documents">
+                        {% for obj in category.documents.all %}
+                            {% include 'documentation/partials/content_summary.html' with obj=obj kind='document' only %}
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock content %}

--- a/lacommunaute/templates/documentation/category_list.html
+++ b/lacommunaute/templates/documentation/category_list.html
@@ -1,0 +1,42 @@
+{% extends "layouts/base.html" %}
+{% load i18n %}
+{% block title %}
+    {% trans "Documents" %}{{ block.super }}
+{% endblock %}
+{% block meta_description %}
+    Des ressources exclusives pour les professionnels de l'inclusion. Retrouver les ressources nécessaires pour améliorer ses diagnostics socio-professionnels et ses accompagnements des personnes éloignées de l’emploi.
+{% endblock meta_description %}
+{% block content %}
+    <section class="s-title-01 mt-lg-5">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1>{% trans "Documents" %}</h1>
+                    <h2 class="mt-3">
+                        Retrouver les ressources nécessaires pour améliorer ses diagnostics socio-professionnels et ses accompagnements des personnes éloignées de l’emploi
+                    </h2>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                {% for category in categories %}
+                    {% include 'documentation/partials/content_summary.html' with obj=category kind='category' only %}
+                {% endfor %}
+            </div>
+        </div>
+    </section>
+    {% if user.is_superuser %}
+        <section class="s-section">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="col-12">
+                        <a href="#" aria-label="Ajouter une catégorie documentaire" role="button" class="btn btn-outline-primary">Ajouter une catégorie documentaire</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
+{% endblock content %}

--- a/lacommunaute/templates/documentation/category_list.html
+++ b/lacommunaute/templates/documentation/category_list.html
@@ -33,7 +33,7 @@
             <div class="s-section__container container">
                 <div class="s-section__row row">
                     <div class="col-12">
-                        <a href="#" aria-label="Ajouter une catégorie documentaire" role="button" class="btn btn-outline-primary">Ajouter une catégorie documentaire</a>
+                        <a href="{% url 'documentation:category_create' %}" aria-label="Ajouter une catégorie documentaire" role="button" class="btn btn-outline-primary">Ajouter une catégorie documentaire</a>
                     </div>
                 </div>
             </div>

--- a/lacommunaute/templates/documentation/partials/content_summary.html
+++ b/lacommunaute/templates/documentation/partials/content_summary.html
@@ -1,0 +1,29 @@
+<div class="col-12 col-md-4 mb-3 mb-md-5">
+    <div class="card c-card has-one-link-inside h-100">
+        {% if obj.image %}
+            <div class="card-header card-header-thumbnail rounded">
+                <img src="{{ obj.image.url }}" alt="{{ obj.name }}" class="img-fitcover img-fluid" loading="lazy" />
+            </div>
+        {% endif %}
+        <div class="card-body pb-0">
+            <p class="h3 lh-base">{{ obj.name }}</p>
+            <div>
+                {% for tag in obj.tags.all %}<span class="tag bg-info-lighter text-info">{{ tag.name }}</span>{% endfor %}
+            </div>
+            {% if obj.short_description %}<div class="mt-3">{{ obj.short_description }}</div>{% endif %}
+        </div>
+        <div class="card-footer text-end">
+            {% if kind == "document" %}
+                <a href="#" class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="document">
+                    <span>Consulter la fiche</span>
+                    <i class="ri-arrow-right-line ri-lg"></i>
+                </a>
+            {% elif kind == "category" %}
+                <a href="#" class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="category">
+                    <span>Consulter les fiches du thème</span>
+                    <i class="ri-arrow-right-line ri-lg"></i>
+                </a>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/lacommunaute/templates/documentation/partials/content_summary.html
+++ b/lacommunaute/templates/documentation/partials/content_summary.html
@@ -19,7 +19,11 @@
                     <i class="ri-arrow-right-line ri-lg"></i>
                 </a>
             {% elif kind == "category" %}
-                <a href="#" class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="category">
+                <a href="{% url 'documentation:category_detail' obj.slug obj.pk %}"
+                   class="btn btn-sm btn-ico btn-link stretched-link matomo-event"
+                   data-matomo-category="engagement"
+                   data-matomo-action="view"
+                   data-matomo-option="category">
                     <span>Consulter les fiches du thème</span>
                     <i class="ri-arrow-right-line ri-lg"></i>
                 </a>

--- a/lacommunaute/templates/documentation/partials/image_and_desc.html
+++ b/lacommunaute/templates/documentation/partials/image_and_desc.html
@@ -1,0 +1,11 @@
+{% load str_filters %}
+{% if obj.image %}
+    <div class="col-12 col-sm-auto mb-3">
+        <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+            <img src="{{ obj.image.url }}" alt="{{ obj.name }}" class="rounded img-fluid" />
+        </div>
+    </div>
+{% endif %}
+<div class="col-12">
+    <article class="textarea_cms_md">{{ obj.description.rendered|urlizetrunc_target_blank:30|img_fluid }}</article>
+</div>

--- a/lacommunaute/templates/documentation/partials/title_and_shortdesc.html
+++ b/lacommunaute/templates/documentation/partials/title_and_shortdesc.html
@@ -1,0 +1,11 @@
+<section class="s-title-01 mt-lg-5">
+    <div class="s-title-01__container container">
+        <div class="s-title-01__row row">
+            <div class="s-title-01__col col-12">
+                <h1>{{ obj.name }}</h1>
+                {% if user.is_superuser %}<a href="{{ obj.get_update_url }}"><small>Mettre à jour</small></a>{% endif %}
+                {% if obj.short_description %}<h2 class="mt-3">{{ obj.short_description }}</h2>{% endif %}
+            </div>
+        </div>
+    </div>
+</section>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -10,7 +10,7 @@
 {% block body_class %}p-home{{ block.super }}{% endblock %}
 {% block content %}
     {% url 'forum_conversation_extension:topics' as publicforum_url %}
-    {% url None as documentation_url %}
+    {% url 'documentation:category_list' as documentation_url %}
     {% url 'event:current' as event_url %}
     {% url 'surveys:dsp_create' as dsp_url %}
     <section class="s-home-title-01 s-home-title-01--communaute mb-md-6 mb-lg-10" style="--home-title-bg: url({% static 'images/commu-home-illu-02b-light.png' %})">

--- a/lacommunaute/templates/partials/ask_a_question.html
+++ b/lacommunaute/templates/partials/ask_a_question.html
@@ -21,7 +21,11 @@
         </div>
         <div class="col-12 col-lg-auto py-1 py-lg-0 px-lg-0 text-center">ou</div>
         <div class="col-12 col-lg-auto">
-            <a href="#" class="btn btn-outline-primary btn-ico btn-block matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation">
+            <a href="{% url 'documentation:category_list' %}"
+               class="btn btn-outline-primary btn-ico btn-block matomo-event"
+               data-matomo-category="engagement"
+               data-matomo-action="view"
+               data-matomo-option="documentation">
                 <span>Consulter la documentation</span>
             </a>
         </div>

--- a/lacommunaute/templates/partials/breadcrumb.html
+++ b/lacommunaute/templates/partials/breadcrumb.html
@@ -5,7 +5,7 @@
             <li class="breadcrumb-item">{% trans "Back to" %}</li>
             <li class="breadcrumb-item">
                 {% if forum.is_in_documentation_area %}
-                    <a href="#" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation_breadcrumb">{% trans "Documents" %}</a>
+                    <a href="{% url 'documentation:category_list' %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation_breadcrumb">{% trans "Documents" %}</a>
                 {% else %}
                     <a href="{% url 'forum_conversation_extension:topics' %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="topics_breadcrumb">{% trans "Discussion area" %}</a>
                 {% endif %}

--- a/lacommunaute/templates/partials/footer.html
+++ b/lacommunaute/templates/partials/footer.html
@@ -14,7 +14,7 @@
                                 <a href="{% url 'forum_conversation_extension:topics' %}">{% trans "Discussion area" %}</a>
                             </li>
                             <li>
-                                <a href="#">{% trans "Documents" %}</a>
+                                <a href="{% url 'documentation:category_list' %}">{% trans "Documents" %}</a>
                             </li>
                             <li>
                                 <a href="{% url 'event:current' %}">{% trans "Events" %}</a>

--- a/lacommunaute/templates/partials/header.html
+++ b/lacommunaute/templates/partials/header.html
@@ -4,7 +4,7 @@
 {% load forum_member_tags %}
 {% url 'pages:home' as home_url %}
 {% url 'forum_conversation_extension:topics' as publicforum_url %}
-{% url 'forum_extension:documentation' as documentation_url %}
+{% url 'documentation:category_list' as documentation_url %}
 {% url 'members:seekers' as seeker_url %}
 {% url 'search:index' as search_url %}
 {% url 'surveys:dsp_create' as dsp_url %}

--- a/lacommunaute/utils/abstract_models.py
+++ b/lacommunaute/utils/abstract_models.py
@@ -3,9 +3,12 @@ from django.db import models
 from django.utils.encoding import force_str
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
+
+# TODO: define it in the project instead of importing it from machina
 from machina.models.fields import MarkupTextField
 from storages.backends.s3boto3 import S3Boto3Storage
 
+from lacommunaute.utils.html import wrap_iframe_in_div_tag
 from lacommunaute.utils.validators import validate_image_size
 
 
@@ -38,4 +41,6 @@ class Publication(DatedModel):
 
     def save(self, *args, **kwargs):
         self.slug = slugify(force_str(self.name), allow_unicode=True)
+        if self.description:
+            self.description.raw = wrap_iframe_in_div_tag(self.description.raw)
         super().save(*args, **kwargs)


### PR DESCRIPTION
Issue #765 

## Description

🎸 Ajouter des `ListView`, `DetailView`, `CreateView` et `UpdateView` pour le modèle `Category` 
🎸 Réimplémenter les liens vers la route `/documentation/`

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🎨 changement d'UI

### Points d'attention

🦺 suite PR #785 
🦺 pagination non implémentée dans `CategoryListView`. A traiter quand le nombre de catégory sera supérieur à 20 * 3.
🦺 modification des champs obligatoires et optionnels dans le modèle abstrait `Publication`
🦺 reprise de la PR #780 sur la factorisation de `wrap_iframe_in_div_tag`


### Captures d'écran (optionnel)

CategoryListView

![image](https://github.com/user-attachments/assets/37520915-f562-4910-80f0-b5cf8d8dff9b)

lien de création d'une nouvelle catégorie pour les superusers

![image](https://github.com/user-attachments/assets/38f4ee2f-586c-4d21-8ee1-7168b12ee833)

CategoryDetailView avec le lien de mise à jour pour les superusers

![image](https://github.com/user-attachments/assets/14735c6d-91e5-429d-9916-dd9792955a3e)

CategoryUpdateView

![image](https://github.com/user-attachments/assets/ef0980d0-d3bd-4bbe-9ca8-3c3d6edfc646)
