### PR TITLE
feat: page parking

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,9 @@ INCLUSION_CONNECT_BASE_URL=http://127.0.0.1:8080
 INCLUSION_CONNECT_CLIENT_ID=local_inclusion_connect
 INCLUSION_CONNECT_CLIENT_SECRET=password
 
+# parking page
+PARKING_PAGE=True
+
 # Path to the itou-backup project repository.
 PATH_TO_BACKUPS=~/path/to/backups
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ POSTGRESQL_ADDON_USER ?= communaute
 POSTGRESQL_ADDON_PASSWORD ?= password
 POSTGRESQL_ADDON_URI ?= "postgresql://$(POSTGRESQL_ADDON_USER):$(POSTGRESQL_ADDON_PASSWORD)@$(POSTGRESQL_ADDON_HOST):$(POSTGRESQL_ADDON_PORT)/$(POSTGRESQL_ADDON_DB)"
 
+DJLINT_EXCLUDE ?= lacommunaute/templates/middleware/
+
 # QUALITY ASSURANCE
 # ~~~~~~~~~~~~~~~~~
 # The following rules can be used to check code quality, import sorting, etc.
@@ -14,7 +16,7 @@ POSTGRESQL_ADDON_URI ?= "postgresql://$(POSTGRESQL_ADDON_USER):$(POSTGRESQL_ADDO
 quality:
 	black --check lacommunaute
 	ruff check lacommunaute
-	djlint --lint --check lacommunaute
+	djlint --lint --check lacommunaute --exclude $(DJLINT_EXCLUDE)
 
 fix:
 	black lacommunaute

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,6 +17,7 @@ APPS_DIR = os.path.abspath(os.path.join(ROOT_DIR, "lacommunaute"))
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
+PARKING_PAGE = os.getenv("PARKING_PAGE", "False") == "True"
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "communaute.inclusion.beta.gouv.fr,").split(",")
 
@@ -96,6 +97,7 @@ DJANGO_MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "lacommunaute.utils.middleware.ParkingPageMiddleware",
 ]
 
 THIRD_PARTIES_MIDDLEWARE = [

--- a/lacommunaute/templates/middleware/parking.html
+++ b/lacommunaute/templates/middleware/parking.html
@@ -1,0 +1,80 @@
+{% load static %}
+{% load compress %}
+{% load theme_inclusion %}
+<!DOCTYPE html>
+<html lang="fr">
+    <head>
+        <meta charset="utf-8">
+        <title>Améliorations en cours</title>
+        <link rel="shortcut icon" href="{% static_theme_images "favicon.ico" %}" type="image/ico">
+        {% import_static_CSS_theme_inclusion %}
+        {% compress css %}
+            <link rel="stylesheet" href="{% static 'stylesheets/itou_communaute.scss' %}" type="text/x-scss">
+        {% endcompress %}
+    </head>
+    <body id="top">
+        <header role="banner" id="header">
+            <section class="s-header">
+                <div class="s-header__container container">
+                    <div class="s-header__row row">
+                        <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pe-0">
+                            <a href="{% url 'pages:home' %}" class="s-header__logo-ministere">
+                                <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française">
+                            </a>
+                        </div>
+                        <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
+                            <a href="{% url 'pages:home' %}">
+                                <img src="{% static_theme_images 'logo-communaute-inclusion.svg' %}" height="90" alt="La communauté de l'inclusion">
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </header>
+        <main id="main" role="main" class="s-main">
+            <section class="s-cms">
+                <div class="s-cms__container container container-max-lg">
+                    <div class="s-cms__row row">
+                        <div class="s-cms__col col-12">
+                            <article>
+                                <h1 class="h2">
+                                    Nous faisons quelques améliorations sur le site de la communauté.
+                                    <br>
+                                    Elles sont bientôt terminées … promis !
+                                </h1>
+                                <div style="width:100%;height:0;padding-bottom:56%;position:relative;">
+                                    <iframe src="https://giphy.com/embed/8vnjJZSKFYUa13gGri" width="100%" height="100%" style="position:absolute" frameBorder="0" class="giphy-embed" allowFullScreen></iframe>
+                                </div>
+                            </article>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
+        <footer role="contentinfo" id="footer">
+            <section class="s-footer-gip">
+                <div class="s-footer-gip__container container">
+                    <div class="s-footer-gip__row row">
+                        <div class="s-footer-gip__col s-footer-gip__col--logo col-12 col-md-6 col-lg-auto">
+                            <a href="https://inclusion.beta.gouv.fr/" target="_blank" aria-label="Découvrez les services de la plateforme de l'inclusion (lien externe)">
+                                <img src="{% static_theme_images 'logo-plateforme-inclusion.svg' %}" height="80" alt="Logo de la Plateforme de l'inclusion">
+                            </a>
+                        </div>
+                        <div class="s-footer-gip__col col-12 col-md-6 col-lg">
+                            <p class="mb-1">
+                                <strong>Ce service fait partie de la Plateforme de l’inclusion</strong>
+                            </p>
+                            <p class="m-0">
+                                Découvrez les outils qui portent l'inclusion au
+                                <br class="d-none d-md-inline">
+                                coeur de leur service. A chaque service, son objectif.
+                                <br>
+                                <a href="https://inclusion.beta.gouv.fr/" target="_blank" class="has-external-link" aria-label="Découvrez les services de la plateforme de l'inclusion (lien externe)">Découvrez nos services</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </footer>
+    </body>
+</html>

--- a/lacommunaute/utils/middleware.py
+++ b/lacommunaute/utils/middleware.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.shortcuts import render
+
+
+class ParkingPageMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if settings.PARKING_PAGE and not request.path.startswith("/admin/"):
+            return render(request, "middleware/parking.html")
+        response = self.get_response(request)
+        return response

--- a/lacommunaute/utils/tests/tests_middleware.py
+++ b/lacommunaute/utils/tests/tests_middleware.py
@@ -1,0 +1,15 @@
+from django.test import TestCase, override_settings
+
+
+class ParkingMiddlewareTest(TestCase):
+    @override_settings(PARKING_PAGE=True)
+    def test_parking_page_middleware(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "middleware/parking.html")
+
+    @override_settings(PARKING_PAGE=False)
+    def test_no_parking_page_middleware(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "pages/home.html")


### PR DESCRIPTION
## Description

🎸 Ajout d'un `middleware` pour activer une page parking lors des maintenances techniques à venir : migration IC #731 , et migration de la documentation #765

## Type de changement

🚧 technique

### Points d'attention

🦺 Ajout de la variable d'environnement `PARKING_PAGE`
🦺 `ParkingPageMiddleware` attrape toutes les requêtes sauf celles vers l'admin lorsqu'il est actif.
🦺 exclure le template `parking.html` du contrôle de `djlint` dans la CI (`make quality`)


### Captures d'écran (optionnel)

page parking

![image](https://github.com/user-attachments/assets/7ad1960e-171e-4d46-b177-11c2084dea9f)

