### PR TITLE
refactor(documentation): partie 5, ajout de la vue de consultation de détail du modèle `document` de l'app `documentation`

### DIFF
--- a/lacommunaute/documentation/models.py
+++ b/lacommunaute/documentation/models.py
@@ -38,3 +38,8 @@ class Document(Publication):
 
     def __str__(self):
         return f"{self.name}"
+
+    def get_absolute_url(self):
+        return reverse(
+            "documentation:document_detail", kwargs={"category_pk": self.category.pk, "pk": self.pk, "slug": self.slug}
+        )

--- a/lacommunaute/documentation/tests/__snapshots__/tests_category_detail_view.ambr
+++ b/lacommunaute/documentation/tests/__snapshots__/tests_category_detail_view.ambr
@@ -29,6 +29,7 @@
               <div class="s-title-01__col col-12">
                   <h1>Test Category</h1>
                   
+                  
                   <h2 class="mt-3">Test short description</h2>
               </div>
           </div>
@@ -99,7 +100,7 @@
           </div>
           <div class="card-footer text-end">
               
-                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="#">
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[PK of Category]/test-document-[PK of Document]/">
                       <span>Consulter la fiche</span>
                       <i class="ri-arrow-right-line ri-lg"></i>
                   </a>
@@ -148,6 +149,7 @@
           <div class="s-title-01__row row">
               <div class="s-title-01__col col-12">
                   <h1>Test Category</h1>
+                  
                   
                   <h2 class="mt-3">Test short description</h2>
               </div>
@@ -221,7 +223,7 @@
           </div>
           <div class="card-footer text-end">
               
-                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="#">
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[PK of Category]/test-document-[PK of Document]/">
                       <span>Consulter la fiche</span>
                       <i class="ri-arrow-right-line ri-lg"></i>
                   </a>
@@ -270,6 +272,7 @@
           <div class="s-title-01__row row">
               <div class="s-title-01__col col-12">
                   <h1>Test Category</h1>
+                  
                   
                   <h2 class="mt-3">Test short description</h2>
               </div>
@@ -341,7 +344,7 @@
           </div>
           <div class="card-footer text-end">
               
-                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="#">
+                  <a class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[PK of Category]/test-document-[PK of Document]/">
                       <span>Consulter la fiche</span>
                       <i class="ri-arrow-right-line ri-lg"></i>
                   </a>

--- a/lacommunaute/documentation/tests/__snapshots__/tests_category_detail_view.ambr
+++ b/lacommunaute/documentation/tests/__snapshots__/tests_category_detail_view.ambr
@@ -11,12 +11,10 @@
       <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
               
           </ol>
       </nav>
@@ -133,12 +131,10 @@
       <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
               
           </ol>
       </nav>
@@ -257,12 +253,10 @@
       <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
               
           </ol>
       </nav>

--- a/lacommunaute/documentation/tests/__snapshots__/tests_document_detail_view.ambr
+++ b/lacommunaute/documentation/tests/__snapshots__/tests_document_detail_view.ambr
@@ -1,0 +1,404 @@
+# serializer version: 1
+# name: test_detail_view[<lambda>-document_detail_view][document_detail_view]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[Slug of Category]-[PK of Category]/">Test Category</a>
+                  </li>
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Document</h1>
+                  
+                      <div>
+                          
+                      </div>
+                  
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="col-12 col-lg-9">
+                      <div class="row align-items-sm-center mb-3">
+                          <div class="col-12 col-sm mb-3">
+  <span class="fs-sm text-muted">Mis à jour le [CURRENT DATE]</span>
+  </div>
+                          
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Document" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+                  <div class="col-12 col-lg-3 vertical-line">
+                      <p class="h3 text-decoration-none d-inline-block">Les autres fiches du thème Test Category</p>
+                      <ul class="nav nav-tabs flex-column">
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 3</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 2</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 1</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link active" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">Test Document</a>
+                              </li>
+                          
+                      </ul>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_detail_view[<lambda>-document_detail_view_with_certified_document][document_detail_view_with_certified_document]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[Slug of Category]-[PK of Category]/">Test Category</a>
+                  </li>
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Document</h1>
+                  
+                      <div>
+                          
+                      </div>
+                  
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="col-12 col-lg-9">
+                      <div class="row align-items-sm-center mb-3">
+                          <div class="col-12 col-sm mb-3">
+      <span class="badge badge-xs rounded-pill bg-communaute text-white text-decoration-none">
+          <i class="ri-checkbox-circle-fill"></i>
+          Certifiée par la communauté de l'inclusion
+      </span>
+  
+  <span class="fs-sm text-muted">Mis à jour le [CURRENT DATE]</span>
+  </div>
+                          
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Document" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+                  <div class="col-12 col-lg-3 vertical-line">
+                      <p class="h3 text-decoration-none d-inline-block">Les autres fiches du thème Test Category</p>
+                      <ul class="nav nav-tabs flex-column">
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 3</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 2</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 1</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link active" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">Test Document</a>
+                              </li>
+                          
+                      </ul>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_detail_view[<lambda>-document_detail_view_with_partner][document_detail_view_with_partner]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[Slug of Category]-[PK of Category]/">Test Category</a>
+                  </li>
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Document</h1>
+                  
+                      <div>
+                          
+                      </div>
+                  
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="col-12 col-lg-9">
+                      <div class="row align-items-sm-center mb-3">
+                          <div class="col-12 col-sm mb-3">
+  <span class="fs-sm text-muted">Mis à jour le [CURRENT DATE]</span>
+  </div>
+                          
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Document" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  
+                          
+                              <div class="col-12 col-sm-auto mt-3" id="partner_area">
+                                  <a href="/partenaires/[Slug of Partner]-[PK of Partner]/">
+      <div class="d-flex gap-3 align-items-center mb-2">
+          
+          <h4>Fiche co-rédigée en partenariat avec Best Partner Ever</h4>
+      </div>
+  </a>
+  
+                              </div>
+                          
+                      </div>
+                  </div>
+                  <div class="col-12 col-lg-3 vertical-line">
+                      <p class="h3 text-decoration-none d-inline-block">Les autres fiches du thème Test Category</p>
+                      <ul class="nav nav-tabs flex-column">
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 3</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 2</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 1</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link active" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">Test Document</a>
+                              </li>
+                          
+                      </ul>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_detail_view[<lambda>-document_detail_view_with_tags][document_detail_view_with_tags]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      
+  <div class="container">
+      <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+          <ol class="breadcrumb">
+              <li class="breadcrumb-item">Retourner vers</li>
+              
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
+                  </li>
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="document" href="/documentation/[Slug of Category]-[PK of Category]/">Test Category</a>
+                  </li>
+              
+          </ol>
+      </nav>
+  </div>
+  
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+      <div class="s-title-01__container container">
+          <div class="s-title-01__row row">
+              <div class="s-title-01__col col-12">
+                  <h1>Test Document</h1>
+                  
+                      <div>
+                          <span class="tag bg-info-lighter text-info">tag</span>
+                      </div>
+                  
+                  
+                  <h2 class="mt-3">Test short description</h2>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="col-12 col-lg-9">
+                      <div class="row align-items-sm-center mb-3">
+                          <div class="col-12 col-sm mb-3">
+  <span class="fs-sm text-muted">Mis à jour le [CURRENT DATE]</span>
+  </div>
+                          
+  
+      <div class="col-12 col-sm-auto mb-3">
+          <div class="d-none d-md-block forum-image mt-3" loading="lazy">
+              <img alt="Test Document" class="rounded img-fluid" src="[img src]"/>
+          </div>
+      </div>
+  
+  <div class="col-12">
+      <article class="textarea_cms_md"><p>Test description</p></article>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+                  <div class="col-12 col-lg-3 vertical-line">
+                      <p class="h3 text-decoration-none d-inline-block">Les autres fiches du thème Test Category</p>
+                      <ul class="nav nav-tabs flex-column">
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 3</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 2</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">titre 1</a>
+                              </li>
+                          
+                              <li class="nav-item">
+                                  <a class="nav-link active" href="/documentation/[PK of Category]/[Slug of Document]-[PK of Document]/">Test Document</a>
+                              </li>
+                          
+                      </ul>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---

--- a/lacommunaute/documentation/tests/tests_category_detail_view.py
+++ b/lacommunaute/documentation/tests/tests_category_detail_view.py
@@ -23,7 +23,12 @@ def test_category_detail_view_with_tagged_documents(client, db, category, active
     url = f"{category.get_absolute_url()}?tag={active_tag}" if active_tag else category.get_absolute_url()
     response = client.get(url)
     assert response.status_code == 200
-    content = parse_response_to_soup(response, selector="main", replace_img_src=True, replace_in_href=[category])
+    content = parse_response_to_soup(
+        response,
+        selector="main",
+        replace_img_src=True,
+        replace_in_href=[category] + [doc for doc in category.documents.all()],
+    )
     assert str(content) == snapshot(name=snapshot_name)
 
 

--- a/lacommunaute/documentation/tests/tests_document_detail_view.py
+++ b/lacommunaute/documentation/tests/tests_document_detail_view.py
@@ -1,0 +1,55 @@
+import pytest
+
+from lacommunaute.documentation.factories import DocumentFactory
+from lacommunaute.partner.factories import PartnerFactory
+from lacommunaute.utils.testing import parse_response_to_soup  # noqa
+
+
+# test avec/sans partenaire
+# test certifiée/non certifiée
+# test avec/sans tags
+
+
+@pytest.fixture(name="document")
+def fixture_document(db):
+    document = DocumentFactory(for_snapshot=True)
+    for titre, short_desc, desc in [(f"titre {i}", f"short desc {i}", f"desc {i}") for i in range(1, 4)]:
+        DocumentFactory(category=document.category, name=titre, short_description=short_desc, description=desc)
+    return document
+
+
+@pytest.mark.parametrize(
+    "setup_func, snapshot_name",
+    [
+        (lambda document: None, "document_detail_view"),
+        (
+            lambda document: setattr(document, "partner", PartnerFactory(for_snapshot=True)) or document.save(),
+            "document_detail_view_with_partner",
+        ),
+        (lambda document: document.tags.add("tag"), "document_detail_view_with_tags"),
+        (
+            lambda document: setattr(document, "certified", True) or document.save(),
+            "document_detail_view_with_certified_document",
+        ),
+    ],
+)
+def test_detail_view(client, db, document, snapshot, setup_func, snapshot_name):
+    setup_func(document)
+    response = client.get(document.get_absolute_url())
+    assert response.status_code == 200
+    replace_in_href = [
+        (f"documentation/{document.category.pk}/", "documentation/[PK of Category]/"),
+        (f"{document.category.slug}-{document.category.pk}", "[Slug of Category]-[PK of Category]"),
+    ] + [(f"{doc.slug}-{doc.pk}", "[Slug of Document]-[PK of Document]") for doc in document.category.documents.all()]
+    if document.partner:
+        replace_in_href.append(
+            (f"/{document.partner.slug}-{document.partner.pk}", "/[Slug of Partner]-[PK of Partner]")
+        )
+    content = parse_response_to_soup(
+        response,
+        selector="main",
+        replace_img_src=True,
+        replace_in_href=replace_in_href,
+        replace_current_date_format="%d/%m/%Y",
+    )
+    assert str(content) == snapshot(name=snapshot_name)

--- a/lacommunaute/documentation/tests/tests_models.py
+++ b/lacommunaute/documentation/tests/tests_models.py
@@ -31,3 +31,7 @@ class TestDocument:
         DocumentFactory(for_snapshot=True)
         with pytest.raises(IntegrityError):
             DocumentFactory(for_snapshot=True)
+
+    def test_get_absolute_url(self, db):
+        document = DocumentFactory()
+        assert document.get_absolute_url() == f"/documentation/{document.category.pk}/{document.slug}-{document.pk}/"

--- a/lacommunaute/documentation/urls.py
+++ b/lacommunaute/documentation/urls.py
@@ -5,6 +5,7 @@ from lacommunaute.documentation.views import (
     CategoryDetailView,
     CategoryListView,
     CategoryUpdateView,
+    DocumentDetailView,
 )
 
 
@@ -16,4 +17,5 @@ urlpatterns = [
     path("<str:slug>-<int:pk>/", CategoryDetailView.as_view(), name="category_detail"),
     path("category/create/", CategoryCreateView.as_view(), name="category_create"),
     path("<str:slug>-<int:pk>/update/", CategoryUpdateView.as_view(), name="category_update"),
+    path("<int:category_pk>/<str:slug>-<int:pk>/", DocumentDetailView.as_view(), name="document_detail"),
 ]

--- a/lacommunaute/documentation/views.py
+++ b/lacommunaute/documentation/views.py
@@ -36,6 +36,12 @@ class CategoryDetailView(DetailView):
         return context
 
 
+class DocumentDetailView(DetailView):
+    model = Document
+    template_name = "documentation/document_detail.html"
+    context_object_name = "document"
+
+
 class CreateUpdateMixin(UserPassesTestMixin):
     def test_func(self):
         return self.request.user.is_superuser

--- a/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
@@ -4,12 +4,12 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
+                  
+                  
               
           </ol>
       </nav>
@@ -20,18 +20,18 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
                   
-                      <li class="breadcrumb-item">
-                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/a-category-[PK of Forum]/">A Category</a>
-                      </li>
+                      
+                          <li class="breadcrumb-item">
+                              <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/a-category-[PK of Forum]/">A Category</a>
+                          </li>
+                      
                   
-              
+                  
               
           </ol>
       </nav>
@@ -42,12 +42,12 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
+                  
+                  
               
           </ol>
       </nav>
@@ -58,24 +58,24 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
                   
-                      <li class="breadcrumb-item">
-                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/b-category-[PK of Forum]/">B Category</a>
-                      </li>
+                      
+                          <li class="breadcrumb-item">
+                              <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/b-category-[PK of Forum]/">B Category</a>
+                          </li>
+                      
                   
-              
+                      
+                          <li class="breadcrumb-item">
+                              <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/b-category-forum-[PK of Forum]/">B Category - Forum</a>
+                          </li>
+                      
                   
-                      <li class="breadcrumb-item">
-                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/b-category-forum-[PK of Forum]/">B Category - Forum</a>
-                      </li>
                   
-              
               
           </ol>
       </nav>
@@ -86,14 +86,14 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
+              
+                  <li class="breadcrumb-item">
                       <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
                   
-              </li>
-              
+                      
                   
-              
+                  
               
           </ol>
       </nav>
@@ -104,18 +104,18 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
+              
+                  <li class="breadcrumb-item">
                       <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
                   
-              </li>
-              
+                      
+                          <li class="breadcrumb-item">
+                              <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/b-forum-[PK of Forum]/">B Forum</a>
+                          </li>
+                      
                   
-                      <li class="breadcrumb-item">
-                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/b-forum-[PK of Forum]/">B Forum</a>
-                      </li>
                   
-              
               
           </ol>
       </nav>
@@ -174,12 +174,12 @@
       <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
+                  
+                  
               
           </ol>
       </nav>

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -289,18 +289,18 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
-                  
-              </li>
-              
-                  
-              
               
                   <li class="breadcrumb-item">
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/forum-b-[PK of Forum]/">Forum B</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
                   </li>
+                  
+                      
+                  
+                  
+                      <li class="breadcrumb-item">
+                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/forum-b-[PK of Forum]/">Forum B</a>
+                      </li>
+                  
               
           </ol>
       </nav>
@@ -311,12 +311,12 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
-                  
-              </li>
               
+                  <li class="breadcrumb-item">
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
+                  </li>
+                  
+                  
               
           </ol>
       </nav>
@@ -327,22 +327,22 @@
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">
           <ol class="breadcrumb">
               <li class="breadcrumb-item">Retourner vers</li>
-              <li class="breadcrumb-item">
-                  
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation_breadcrumb" href="/documentation/">Documentation</a>
-                  
-              </li>
-              
-                  
-                      <li class="breadcrumb-item">
-                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/d-category-[PK of Forum]/">D Category</a>
-                      </li>
-                  
-              
               
                   <li class="breadcrumb-item">
-                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/d-category-forum-[PK of Forum]/">D Category - Forum</a>
+                      <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="topics_breadcrumb" href="/topics/">Espace d'échanges</a>
                   </li>
+                  
+                      
+                          <li class="breadcrumb-item">
+                              <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/d-category-[PK of Forum]/">D Category</a>
+                          </li>
+                      
+                  
+                  
+                      <li class="breadcrumb-item">
+                          <a class="matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/d-category-forum-[PK of Forum]/">D Category - Forum</a>
+                      </li>
+                  
               
           </ol>
       </nav>

--- a/lacommunaute/static/stylesheets/itou_communaute.scss
+++ b/lacommunaute/static/stylesheets/itou_communaute.scss
@@ -220,3 +220,9 @@ span.highlighted {
 .s-home-title-01::after {
   left: 52%;
 }
+
+.vertical-line {
+  border-left: 1px solid #a1a1a1;
+  padding-left: 10px;
+  height: 100%;
+}

--- a/lacommunaute/templates/documentation/document_detail.html
+++ b/lacommunaute/templates/documentation/document_detail.html
@@ -1,0 +1,40 @@
+{% extends "layouts/base.html" %}
+{% load i18n %}
+{% block title %}{{ document.name }}{{ block.super }}{% endblock %}
+{% block meta_description %}
+    {{ document.short_description }}
+{% endblock meta_description %}
+{% block breadcrumb %}
+    {% include "partials/breadcrumb.html" %}
+{% endblock %}
+{% block content %}
+    {% include 'documentation/partials/title_and_shortdesc.html' with obj=document user=user only %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="col-12 col-lg-9">
+                    <div class="row align-items-sm-center mb-3">
+                        <div class="col-12 col-sm mb-3">{% include 'documentation/partials/certified.html' with obj=document only %}</div>
+                        {% include 'documentation/partials/image_and_desc.html' with obj=document only %}
+                        {% if document.partner %}
+                            <div class="col-12 col-sm-auto mt-3" id="partner_area">
+                                {% include "documentation/partials/partner.html" with partner=document.partner only %}
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="col-12 col-lg-3 vertical-line">
+                    <p class="h3 text-decoration-none d-inline-block">Les autres fiches du thème {{ document.category.name }}</p>
+                    <ul class="nav nav-tabs flex-column">
+                        {% for document_in_category in document.category.documents.all %}
+                            <li class="nav-item">
+                                <a href="{% url 'documentation:document_detail' document_in_category.category.id document_in_category.slug document_in_category.pk %}"
+                                   class="nav-link{% if document_in_category.id == document.id %} active{% endif %}">{{ document_in_category.name }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock content %}

--- a/lacommunaute/templates/documentation/partials/certified.html
+++ b/lacommunaute/templates/documentation/partials/certified.html
@@ -1,0 +1,7 @@
+{% if obj.certified %}
+    <span class="badge badge-xs rounded-pill bg-communaute text-white text-decoration-none">
+        <i class="ri-checkbox-circle-fill"></i>
+        Certifiée par la communauté de l'inclusion
+    </span>
+{% endif %}
+<span class="fs-sm text-muted">Mis à jour le {{ obj.updated|date:"d/m/Y" }}</span>

--- a/lacommunaute/templates/documentation/partials/content_summary.html
+++ b/lacommunaute/templates/documentation/partials/content_summary.html
@@ -14,7 +14,11 @@
         </div>
         <div class="card-footer text-end">
             {% if kind == "document" %}
-                <a href="#" class="btn btn-sm btn-ico btn-link stretched-link matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="document">
+                <a href="{% url 'documentation:document_detail' obj.category.pk obj.slug obj.pk %}"
+                   class="btn btn-sm btn-ico btn-link stretched-link matomo-event"
+                   data-matomo-category="engagement"
+                   data-matomo-action="view"
+                   data-matomo-option="document">
                     <span>Consulter la fiche</span>
                     <i class="ri-arrow-right-line ri-lg"></i>
                 </a>

--- a/lacommunaute/templates/documentation/partials/partner.html
+++ b/lacommunaute/templates/documentation/partials/partner.html
@@ -1,0 +1,8 @@
+<a href="{{ partner.get_absolute_url }}">
+    <div class="d-flex gap-3 align-items-center mb-2">
+        {% if partner.logo %}
+            <img src="{{ partner.logo.url }}" alt="{{ partner.name }}" class="img-fluid" width="100" loading="lazy" />
+        {% endif %}
+        <h4>Fiche co-rédigée en partenariat avec {{ partner.name }}</h4>
+    </div>
+</a>

--- a/lacommunaute/templates/documentation/partials/title_and_shortdesc.html
+++ b/lacommunaute/templates/documentation/partials/title_and_shortdesc.html
@@ -3,6 +3,11 @@
         <div class="s-title-01__row row">
             <div class="s-title-01__col col-12">
                 <h1>{{ obj.name }}</h1>
+                {% if obj.tags %}
+                    <div>
+                        {% for tag in obj.tags.all %}<span class="tag bg-info-lighter text-info">{{ tag.name }}</span>{% endfor %}
+                    </div>
+                {% endif %}
                 {% if user.is_superuser %}<a href="{{ obj.get_update_url }}"><small>Mettre à jour</small></a>{% endif %}
                 {% if obj.short_description %}<h2 class="mt-3">{{ obj.short_description }}</h2>{% endif %}
             </div>

--- a/lacommunaute/templates/partials/breadcrumb.html
+++ b/lacommunaute/templates/partials/breadcrumb.html
@@ -3,23 +3,36 @@
     <nav class="c-breadcrumb" aria-label="Fil d'ariane">
         <ol class="breadcrumb">
             <li class="breadcrumb-item">{% trans "Back to" %}</li>
-            <li class="breadcrumb-item">
-                {% if forum.is_in_documentation_area %}
+            {% if document %}
+                <li class="breadcrumb-item">
                     <a href="{% url 'documentation:category_list' %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation_breadcrumb">{% trans "Documents" %}</a>
-                {% else %}
+                </li>
+                <li class="breadcrumb-item">
+                    <a href="{% url 'documentation:category_detail' document.category.slug document.category.pk %}"
+                       class="matomo-event"
+                       data-matomo-category="engagement"
+                       data-matomo-action="view"
+                       data-matomo-option="document">{{ document.category.name }}</a>
+                </li>
+            {% elif forum %}
+                <li class="breadcrumb-item">
                     <a href="{% url 'forum_conversation_extension:topics' %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="topics_breadcrumb">{% trans "Discussion area" %}</a>
-                {% endif %}
-            </li>
-            {% for ancestor in forum.get_ancestors %}
-                {% if not ancestor.is_toplevel_discussion_area %}
+                </li>
+                {% for ancestor in forum.get_ancestors %}
+                    {% if not ancestor.is_toplevel_discussion_area %}
+                        <li class="breadcrumb-item">
+                            <a href="{% url 'forum_extension:forum' ancestor.slug ancestor.id %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">{{ ancestor.name }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+                {% if topic and not forum.is_toplevel_discussion_area %}
                     <li class="breadcrumb-item">
-                        <a href="{% url 'forum_extension:forum' ancestor.slug ancestor.id %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">{{ ancestor.name }}</a>
+                        <a href="{% url 'forum_extension:forum' forum.slug forum.id %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">{{ forum.name }}</a>
                     </li>
                 {% endif %}
-            {% endfor %}
-            {% if topic and not forum.is_toplevel_discussion_area %}
+            {% else %}
                 <li class="breadcrumb-item">
-                    <a href="{% url 'forum_extension:forum' forum.slug forum.id %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forum">{{ forum.name }}</a>
+                    <a href="{% url 'documentation:category_list' %}" class="matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="documentation_breadcrumb">{% trans "Documents" %}</a>
                 </li>
             {% endif %}
         </ol>

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -606,6 +606,11 @@ class UtilsParseResponseToSoupTest(TestCase):
         response = HttpResponse('<html><head></head><body><div id="foo">bar</div></body></html>')
         assert str(parse_response_to_soup(response, selector="#foo")) == '<div id="foo">bar</div>'
 
+    def test_replace_img_src(self):
+        response = HttpResponse('<html><head></head><body><img src="http://server.com/image.jpg"></body></html>')
+        soup = parse_response_to_soup(response, replace_img_src=True)
+        assert str(soup) == '<html><head></head><body><img src="[img src]"/></body></html>'
+
     def test_replace_in_href_mixing_tuple_and_object(self):
         topic = TopicFactory()
         response = HttpResponse(

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -611,6 +611,13 @@ class UtilsParseResponseToSoupTest(TestCase):
         soup = parse_response_to_soup(response, replace_img_src=True)
         assert str(soup) == '<html><head></head><body><img src="[img src]"/></body></html>'
 
+    def test_replace_current_date(self):
+        response = HttpResponse(
+            f'<html><head></head><body><div>Today is {datetime.now().strftime("%d/%m/%Y")}</div></body></html>'
+        )
+        soup = parse_response_to_soup(response, replace_current_date_format="%d/%m/%Y")
+        assert str(soup) == "<html><head></head><body><div>Today is [CURRENT DATE]</div></body></html>"
+
     def test_replace_in_href_mixing_tuple_and_object(self):
         topic = TopicFactory()
         response = HttpResponse(


### PR DESCRIPTION
Issue #765 

## Description

🎸 Ajout de la vue de detail de `Document` et de ses gabarits

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🎨 changement d'UI

### Points d'attention

🦺 suite PR #786 
🦺 Mise à jour de `breadcrumb`
🦺 Ajout d'un test manquant concernant le remplacement des images dans `parse_response_to_soup`
🦺 Enrichissement de `parse_response_to_soup` pour rendre les snapshot agnostiques vis-à-vis des dates de mises à jour


### Captures d'écran (optionnel)

DocumentDetailView

![image](https://github.com/user-attachments/assets/da80870a-b6fc-466b-912e-4339285ff2fe)

