### PR TITLE
feat(stats): page de statistique des fiches pratiques

### DIFF
--- a/lacommunaute/static/stylesheets/itou_communaute.scss
+++ b/lacommunaute/static/stylesheets/itou_communaute.scss
@@ -220,9 +220,3 @@ span.highlighted {
 .s-home-title-01::after {
   left: 52%;
 }
-
-th {
-  a {
-    text-decoration: none;
-  }
-}

--- a/lacommunaute/static/stylesheets/itou_communaute.scss
+++ b/lacommunaute/static/stylesheets/itou_communaute.scss
@@ -220,3 +220,9 @@ span.highlighted {
 .s-home-title-01::after {
   left: 52%;
 }
+
+th {
+  a {
+    text-decoration: none;
+  }
+}

--- a/lacommunaute/stats/factories.py
+++ b/lacommunaute/stats/factories.py
@@ -38,5 +38,7 @@ class ForumStatFactory(factory.django.DjangoModelFactory):
         model = ForumStat
 
     class Params:
-        for_snapshot = factory.Trait(period="week", date=datetime.date(2024, 5, 20))
+        for_snapshot = factory.Trait(
+            period="week", date=datetime.date(2024, 5, 20), visits=100, entry_visits=50, time_spent=23700
+        )
         for_snapshot_older = factory.Trait(period="week", date=datetime.date(2024, 5, 13))

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -58,28 +58,28 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       <i class="ri-arrow-down-s-fill"></i>
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
                                                       Nombre de Visites
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
                                                       Nombres de notations
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
                                                       Moyenne des notations
                                                       
                                                   </a>
@@ -197,28 +197,28 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
                                                       Nombre de Visites
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
                                                       Nombres de notations
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
                                                       Moyenne des notations
                                                       <i class="ri-arrow-down-s-fill"></i>
                                                   </a>
@@ -336,28 +336,28 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
                                                       Nombre de Visites
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
                                                       Nombres de notations
                                                       <i class="ri-arrow-down-s-fill"></i>
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
                                                       Moyenne des notations
                                                       
                                                   </a>
@@ -475,28 +475,28 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       <i class="ri-arrow-down-s-fill"></i>
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
                                                       Nombre de Visites
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
                                                       Nombres de notations
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
                                                       Moyenne des notations
                                                       
                                                   </a>
@@ -614,28 +614,28 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
                                                       Nombre de Visites
                                                       <i class="ri-arrow-down-s-fill"></i>
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
                                                       Nombres de notations
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
                                                       Moyenne des notations
                                                       
                                                   </a>
@@ -753,28 +753,28 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       <i class="ri-arrow-down-s-fill"></i>
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
                                                       Nombre de Visites
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
                                                       Nombres de notations
                                                       
                                                   </a>
                                               </th>
                                           
                                               <th scope="col">
-                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
                                                       Moyenne des notations
                                                       
                                                   </a>

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -11,6 +11,701 @@
           </nav>
   '''
 # ---
+# name: TestForumStatView.test_sort_key[None-sort_by_sum_time_spent][sort_by_sum_time_spent]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestForumStatView.test_sort_key[avg_rating-sort_by_avg_rating][sort_by_avg_rating]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestForumStatView.test_sort_key[count_rating-sort_by_count_rating][sort_by_count_rating]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestForumStatView.test_sort_key[sum_time_spent-sort_by_sum_time_spent][sort_by_sum_time_spent]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestForumStatView.test_sort_key[sum_visits-sort_by_sum_visits][sort_by_sum_visits]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
 # name: TestForumStatWeekArchiveView.test_header_and_breadcrumb[breadcrumb]
   '''
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -50,7 +50,7 @@
                                   <br/>
                                   Le nombre et la moyenne des notations sont calculés en temps réel.
                                   <br/>
-                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                               </caption>
                               
                                   <thead>
@@ -189,7 +189,7 @@
                                   <br/>
                                   Le nombre et la moyenne des notations sont calculés en temps réel.
                                   <br/>
-                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                               </caption>
                               
                                   <thead>
@@ -328,7 +328,7 @@
                                   <br/>
                                   Le nombre et la moyenne des notations sont calculés en temps réel.
                                   <br/>
-                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                               </caption>
                               
                                   <thead>
@@ -467,7 +467,7 @@
                                   <br/>
                                   Le nombre et la moyenne des notations sont calculés en temps réel.
                                   <br/>
-                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                               </caption>
                               
                                   <thead>
@@ -606,7 +606,7 @@
                                   <br/>
                                   Le nombre et la moyenne des notations sont calculés en temps réel.
                                   <br/>
-                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                               </caption>
                               
                                   <thead>
@@ -745,7 +745,7 @@
                                   <br/>
                                   Le nombre et la moyenne des notations sont calculés en temps réel.
                                   <br/>
-                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                               </caption>
                               
                                   <thead>

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -92,7 +92,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <a href="">A</a>
                                               <br/>
                                               
                                           </th>
@@ -104,7 +104,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <a href="">B</a>
                                               <br/>
                                               
                                           </th>
@@ -116,7 +116,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <a href="">C</a>
                                               <br/>
                                               
                                           </th>
@@ -128,7 +128,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <a href="">D</a>
                                               <br/>
                                               
                                           </th>
@@ -231,7 +231,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <a href="">D</a>
                                               <br/>
                                               
                                           </th>
@@ -243,7 +243,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <a href="">A</a>
                                               <br/>
                                               
                                           </th>
@@ -255,7 +255,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <a href="">B</a>
                                               <br/>
                                               
                                           </th>
@@ -267,7 +267,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <a href="">C</a>
                                               <br/>
                                               
                                           </th>
@@ -370,7 +370,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <a href="">C</a>
                                               <br/>
                                               
                                           </th>
@@ -382,7 +382,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <a href="">D</a>
                                               <br/>
                                               
                                           </th>
@@ -394,7 +394,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <a href="">A</a>
                                               <br/>
                                               
                                           </th>
@@ -406,7 +406,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <a href="">B</a>
                                               <br/>
                                               
                                           </th>
@@ -509,7 +509,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <a href="">A</a>
                                               <br/>
                                               
                                           </th>
@@ -521,7 +521,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <a href="">B</a>
                                               <br/>
                                               
                                           </th>
@@ -533,7 +533,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <a href="">C</a>
                                               <br/>
                                               
                                           </th>
@@ -545,7 +545,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <a href="">D</a>
                                               <br/>
                                               
                                           </th>
@@ -648,7 +648,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/b-[PK of Forum]/">B</a>
+                                              <a href="">B</a>
                                               <br/>
                                               
                                           </th>
@@ -660,7 +660,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/c-[PK of Forum]/">C</a>
+                                              <a href="">C</a>
                                               <br/>
                                               
                                           </th>
@@ -672,7 +672,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/d-[PK of Forum]/">D</a>
+                                              <a href="">D</a>
                                               <br/>
                                               
                                           </th>
@@ -684,7 +684,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="/forum/a-[PK of Forum]/">A</a>
+                                              <a href="">A</a>
                                               <br/>
                                               
                                           </th>
@@ -692,6 +692,145 @@
                                           <td>70</td>
                                           <td>2</td>
                                           <td>4,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestForumStatView.test_sort_key[unknown-sort_by_sum_time_spent][sort_by_sum_time_spent]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
                                       </tr>
                                   
                               </tbody>

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -167,11 +167,11 @@ class TestStatistiquesPageView:
         assert response.status_code == 200
         assert response.context["stats"] == expected
 
-    def test_link_to_weekly_lastest_stats_view(self, client, db):
+    def test_link_to_document_stats_view(self, client, db):
         url = reverse("stats:statistiques")
         response = client.get(url)
         assert response.status_code == 200
-        assertContains(response, reverse("stats:redirect_to_latest_weekly_stats"))
+        assertContains(response, reverse("stats:document_stats"))
 
 
 class TestMonthlyVisitorsView:

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -286,6 +286,7 @@ class TestForumStatView:
             ("sum_visits", "sort_by_sum_visits"),
             ("avg_rating", "sort_by_avg_rating"),
             ("count_rating", "sort_by_count_rating"),
+            ("unknown", "sort_by_sum_time_spent"),
         ],
     )
     def test_sort_key(self, client, db, document_stats_setup, sort_key, snapshot_name, snapshot):

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -298,6 +298,12 @@ class TestForumStatView:
             )
         ) == snapshot(name=snapshot_name)
 
+    def test_num_queries(self, client, db, document_stats_setup, django_assert_num_queries):
+        django_session_num_of_queries = 6
+        expected_queries_in_view = 1
+        with django_assert_num_queries(expected_queries_in_view + django_session_num_of_queries):
+            client.get(reverse("stats:document_stats"))
+
 
 class TestForumStatWeekArchiveView:
     def get_url_from_date(self, date):

--- a/lacommunaute/stats/urls.py
+++ b/lacommunaute/stats/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from lacommunaute.stats.views import (
     DailyDSPView,
+    DocumentStatsView,
     ForumStatWeekArchiveView,
     MonthlyVisitorsView,
     StatistiquesPageView,
@@ -17,4 +18,5 @@ urlpatterns = [
     path("dsp/", DailyDSPView.as_view(), name="dsp"),
     path("weekly/<int:year>/<int:week>/", ForumStatWeekArchiveView.as_view(), name="forum_stat_week_archive"),
     path("weekly/", redirect_to_latest_weekly_stats, name="redirect_to_latest_weekly_stats"),
+    path("documents/", DocumentStatsView.as_view(), name="document_stats"),
 ]

--- a/lacommunaute/stats/views.py
+++ b/lacommunaute/stats/views.py
@@ -181,9 +181,21 @@ class DocumentStatsView(View):
         )
         return forums
 
+    def get_sort_fields(self):
+        return [
+            {"key": "sum_time_spent", "label": "Temps de lecture"},
+            {"key": "sum_visits", "label": "Nombre de Visites"},
+            {"key": "count_rating", "label": "Nombres de notations"},
+            {"key": "avg_rating", "label": "Moyenne des notations"},
+        ]
+
     def get(self, request, *args, **kwargs):
         forums = self.get_forums_with_forumstats_and_ratings()
-        sort_key = request.GET.get("sort", "sum_time_spent")
+        sort_key = (
+            request.GET.get("sort")
+            if request.GET.get("sort") in [field["key"] for field in self.get_sort_fields()]
+            else "sum_time_spent"
+        )
         forums = forums.order_by("-" + sort_key)
 
         return render(
@@ -192,12 +204,7 @@ class DocumentStatsView(View):
             {
                 "objects": forums,
                 "sort_key": sort_key,
-                "sort_fields": [
-                    {"key": "sum_time_spent", "label": "Temps de lecture"},
-                    {"key": "sum_visits", "label": "Nombre de Visites"},
-                    {"key": "count_rating", "label": "Nombres de notations"},
-                    {"key": "avg_rating", "label": "Moyenne des notations"},
-                ],
+                "sort_fields": self.get_sort_fields(),
             },
         )
 

--- a/lacommunaute/templates/stats/documents.html
+++ b/lacommunaute/templates/stats/documents.html
@@ -37,7 +37,7 @@
                                 <br>
                                 Le nombre et la moyenne des notations sont calculés en temps réel.
                                 <br>
-                                Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                                Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
                             </caption>
                             {% with sort_fields=sort_fields %}
                                 <thead>

--- a/lacommunaute/templates/stats/documents.html
+++ b/lacommunaute/templates/stats/documents.html
@@ -1,0 +1,78 @@
+{% extends "layouts/base.html" %}
+{% load static %}
+{% load i18n %}
+{% load date_filters %}
+{% load str_filters %}
+{% block title %}Statistiques des Fiches Pratiques{{ block.super }}{% endblock %}
+{% block body_class %}p-statistiques{{ block.super }}{% endblock %}
+{% block breadcrumb %}
+    <div class="container">
+        <nav class="c-breadcrumb" aria-label="Fil d'ariane">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item">{% trans "Back to" %}</li>
+                <li class="breadcrumb-item">
+                    <a href="{% url 'stats:statistiques' %}">Statistiques</a>
+                </li>
+            </ol>
+        </nav>
+    </div>
+{% endblock %}
+{% block content %}
+    <section class="s-title-01 mt-lg-5">
+        <div class="s-title-01__container container">
+            <div class="s-title-01__row row">
+                <div class="s-title-01__col col-12">
+                    <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row" id="most_rated">
+                <div class="s-section__col col-12">
+                    <div class="c-box mb-3 mb-md-5">
+                        <table class="table">
+                            <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                <br>
+                                Le nombre et la moyenne des notations sont calculés en temps réel.
+                                <br>
+                                Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin
+                            </caption>
+                            {% with sort_fields=sort_fields %}
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Fiche Pratique</th>
+                                        {% for field in sort_fields %}
+                                            <th scope="col">
+                                                <a href="{{ request.path }}?sort={{ field.key }}">
+                                                    {{ field.label }}
+                                                    {% if sort_key == field.key %}<i class="ri-arrow-down-s-fill"></i>{% endif %}
+                                                </a>
+                                            </th>
+                                        {% endfor %}
+                                    </tr>
+                                </thead>
+                            {% endwith %}
+                            <tbody>
+                                {% for obj in objects %}
+                                    <tr>
+                                        <th scope="row">
+                                            <a href="{{ obj.absolute_url }}">{{ obj.name }}</a>
+                                            <br>
+                                            {% if obj.partner %}<span class="text-muted">en partenariat avec {{ obj.partner.name }}</span>{% endif %}
+                                        </th>
+                                        <td>{{ obj.sum_time_spent|convert_seconds_into_hours }}</td>
+                                        <td>{{ obj.sum_visits }}</td>
+                                        <td>{{ obj.count_rating|default_if_none:"pas de notation" }}</td>
+                                        <td>{{ obj.avg_rating|floatformat:2 }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/lacommunaute/templates/stats/documents.html
+++ b/lacommunaute/templates/stats/documents.html
@@ -45,7 +45,7 @@
                                         <th scope="col">Fiche Pratique</th>
                                         {% for field in sort_fields %}
                                             <th scope="col">
-                                                <a href="{{ request.path }}?sort={{ field.key }}">
+                                                <a href="{{ request.path }}?sort={{ field.key }}" class="text-decoration-none">
                                                     {{ field.label }}
                                                     {% if sort_key == field.key %}<i class="ri-arrow-down-s-fill"></i>{% endif %}
                                                 </a>

--- a/lacommunaute/templates/stats/statistiques.html
+++ b/lacommunaute/templates/stats/statistiques.html
@@ -99,8 +99,8 @@
             </div>
             <div class="s-section__row row">
                 <div class="col-12 col-lg-auto">
-                    <a href="{% url 'stats:redirect_to_latest_weekly_stats' %}" class="btn btn-outline-primary btn-ico btn-block">
-                        Accès aux statistiques hebdomadaires
+                    <a href="{% url 'stats:document_stats' %}" class="btn btn-outline-primary btn-ico btn-block">
+                        Accès aux statistiques des fiches pratiques
                     </a>
                 </div>
             </div>

--- a/lacommunaute/utils/templatetags/date_filters.py
+++ b/lacommunaute/utils/templatetags/date_filters.py
@@ -23,3 +23,12 @@ def relativetimesince_fr(d):
         return f"{date(d,'l')}, {time(d)}"
 
     return f"il y a {timesince(d)}"
+
+
+@register.filter(is_safe=True)
+def convert_seconds_into_hours(value, default=None):
+    if value is None:
+        return "0h 00min"
+    hours = value // 3600
+    minutes = (value % 3600) // 60
+    return f"{hours}h {minutes:02d}min"

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -148,6 +148,15 @@ class UtilsUrlsTestCase(TestCase):
         self.assertEqual(urlize(img), img)
 
 
+class TestUtilsTemplateTags:
+    @pytest.mark.parametrize(
+        "value,expected_result", [(900, "0h 15min"), (3600, "1h 00min"), (7320, "2h 02min"), (None, "0h 00min")]
+    )
+    def test_convert_seconds_into_hours(self, value, expected_result):
+        template = Template("{% load date_filters %}{{ value|convert_seconds_into_hours }}")
+        assert template.render(Context({"value": value})) == expected_result
+
+
 class UtilsTemplateTagsTestCase(TestCase):
     def test_pluralizefr(self):
         """Test `pluralizefr` template tag."""


### PR DESCRIPTION
## Description

🎸 Vue `DocumentStats` pour afficher le temps de lecture cumulé, le nombre de visites, le nombre de notation et la moyenne de notations, de toutes les fiches pratiques.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 les annotations de `ForumStats` et `ForumRating` sont associées via une `SubQuery`

🦺 ajout du templatetag `convert_seconds_into_hours`
🦺 mise à jour de la factory `ForumStatFactory` pour déterminer les valeurs de `visits`, `entry_visits` et `time_spent`
🦺 tri des items par le passage d'un param `sort` dans l'url

### Captures d'écran (optionnel)

page avec tri par défaut

![image](https://github.com/user-attachments/assets/edb499cd-aebb-4479-baad-65833bcfbc0a)

page avec tri sur le nombre de visites

![image](https://github.com/user-attachments/assets/72442619-77fe-4dd6-b67d-42344fa478c8)

bas de la page statistiques avec le lien vers la nouvelle vue

![image](https://github.com/user-attachments/assets/bc14e223-be76-46f9-ae05-aab7dee51da4)

