### PR TITLE
fix: filtrage des questions en utilisant les étiquettes (part 2)

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -83,20 +83,20 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.context_data["loadmoretopic_url"], loadmoretopic_url)
         self.assertEqual(response.context_data["forum"], self.forum)
         self.assertIsNone(response.context_data["rating"])
-        self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.ALL)
         self.assertEqual(list(response.context_data["active_tag"]), [])
 
-        for filter, label in Filters.choices:
-            with self.subTest(filter=filter, label=label):
-                response = self.client.get(self.url + f"?filter={filter}")
+        for filter in Filters:
+            with self.subTest(filter=filter):
+                response = self.client.get(self.url + f"?filter={filter.value}")
                 self.assertEqual(
                     response.context_data["loadmoretopic_url"],
-                    loadmoretopic_url + f"?filter={filter}",
+                    loadmoretopic_url + f"?filter={filter.value}",
                 )
-                self.assertEqual(response.context_data["active_filter_name"], label)
+                self.assertEqual(response.context_data["active_filter"], filter)
 
         response = self.client.get(self.url + "?filter=FAKE")
-        self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.ALL)
 
         tag = Tag.objects.create(name="tag_1", slug="tag_1")
         response = self.client.get(self.url + f"?tag={tag.name}")
@@ -365,14 +365,14 @@ class ForumViewTest(TestCase):
         response = self.client.get(self.url + f"?filter={Filters.NEW.value}")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context_data["paginator"].count, 0)
-        self.assertEqual(response.context_data["active_filter_name"], Filters.NEW.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.NEW)
 
         new_topic = TopicFactory(with_post=True, forum=self.forum)
 
         response = self.client.get(self.url + f"?filter={Filters.NEW.value}")
         self.assertEqual(response.context_data["paginator"].count, 1)
         self.assertContains(response, new_topic.subject, status_code=200)
-        self.assertEqual(response.context_data["active_filter_name"], Filters.NEW.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.NEW)
 
         for topic in Topic.objects.exclude(id=new_topic.id):
             with self.subTest(topic):
@@ -382,7 +382,7 @@ class ForumViewTest(TestCase):
         response = self.client.get(self.url + f"?filter={Filters.CERTIFIED.value}")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context_data["paginator"].count, 0)
-        self.assertEqual(response.context_data["active_filter_name"], Filters.CERTIFIED.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.CERTIFIED)
 
         certified_topic = TopicFactory(with_post=True, with_certified_post=True, forum=self.forum)
 
@@ -390,7 +390,7 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.context_data["paginator"].count, 1)
         self.assertContains(response, certified_topic.subject, status_code=200)
         self.assertContains(response, certified_topic.certified_post.post.content.raw[:100])
-        self.assertEqual(response.context_data["active_filter_name"], Filters.CERTIFIED.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.CERTIFIED)
 
         for topic in Topic.objects.exclude(id=certified_topic.id):
             with self.subTest(topic):

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -84,7 +84,7 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.context_data["forum"], self.forum)
         self.assertIsNone(response.context_data["rating"])
         self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
-        self.assertEqual(response.context_data["active_tags"], "")
+        self.assertEqual(list(response.context_data["active_tag"]), [])
 
         for filter, label in Filters.choices:
             with self.subTest(filter=filter, label=label):
@@ -99,11 +99,8 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
 
         tag = Tag.objects.create(name="tag_1", slug="tag_1")
-        response = self.client.get(self.url + f"?tags=nonexistant,{tag.name}")
-        self.assertIn(tag.slug, response.context_data["active_tags"])
-        self.assertNotIn("nonexistant", response.context_data["active_tags"])
-        self.assertIn(tag.name, response.context_data["active_tags_label"])
-        self.assertNotIn("nonexistant", response.context_data["active_tags_label"])
+        response = self.client.get(self.url + f"?tag={tag.name}")
+        self.assertEqual(tag, response.context_data["active_tag"])
 
     def test_template_name(self):
         response = self.client.get(self.url)
@@ -358,7 +355,7 @@ class ForumViewTest(TestCase):
 
         with self.assertNumQueries(20):
             response = self.client.get(
-                reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug}), {"tags": tag}
+                reverse("forum_extension:forum", kwargs={"pk": self.forum.pk, "slug": self.forum.slug}), {"tag": tag}
             )
         self.assertContains(response, topic.subject)
         self.assertNotContains(response, self.topic.subject)
@@ -608,6 +605,22 @@ class TestDocumentationForumContent:
         assert str(content.select("#partner_area")) == snapshot(name="documentation_forum_with_partner")
 
 
+@pytest.fixture(name="documentation_category_forum_with_descendants")
+def documentation_category_forum_with_descendants_fixture():
+    tags = [faker.word() for _ in range(3)]
+    category_forum = CategoryForumFactory(with_public_perms=True)
+    first_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[0]])
+    second_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[0], tags[1]])
+    third_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[2]])
+    # forum without tags
+    ForumFactory(parent=category_forum, with_public_perms=True)
+
+    # edge case: grand_child is filtered out. No actual use case to display them in the subforum list
+    ForumFactory(parent=third_child, with_public_perms=True, with_tags=[tags[2]])
+
+    return category_forum, tags[0], [first_child, second_child]
+
+
 class TestDocumentationCategoryForumContent:
     def test_documentation_category_subforum_list(
         self, client, db, snapshot, reset_forum_sequence, documentation_forum
@@ -636,36 +649,24 @@ class TestDocumentationCategoryForumContent:
         assert len(add_documentation_control) == 1
         assert str(add_documentation_control[0]) == snapshot(name="documentation_category_add_file_control")
 
-    def test_filter_subforums_on_tags(self, client, db):
-        tags = [faker.word() for _ in range(3)]
-        category_forum = CategoryForumFactory(with_public_perms=True)
-        first_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[0]])
-        second_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[0], tags[1]])
-        third_child = ForumFactory(parent=category_forum, with_public_perms=True, with_tags=[tags[2]])
-        # forum without tags
-        ForumFactory(parent=category_forum, with_public_perms=True)
+    @pytest.mark.parametrize("filtered, sub_forums_count", [(False, 4), (True, 2)])
+    def test_filter_subforums_on_tags(
+        self, client, db, documentation_category_forum_with_descendants, filtered, sub_forums_count
+    ):
+        category_forum, first_tag, subforums_with_first_tag = documentation_category_forum_with_descendants
 
-        # edge case: grand_child is filtered out. No actual use case to display them in the subforum list
-        ForumFactory(parent=third_child, with_public_perms=True, with_tags=[tags[2]])
-
-        # no filter
-        response = client.get(category_forum.get_absolute_url())
-        assert response.status_code == 200
-        assert [node.obj for node in response.context_data["sub_forums"].top_nodes] == list(
-            category_forum.get_children()
+        expected = subforums_with_first_tag if filtered else list(category_forum.get_children())
+        url = (
+            category_forum.get_absolute_url() + f"?forum_tag={first_tag}"
+            if filtered
+            else category_forum.get_absolute_url()
         )
 
-        # filter on one tag
-        response = client.get(category_forum.get_absolute_url() + f"?forum_tag={tags[0]}")
+        response = client.get(url)
         assert response.status_code == 200
-        assert set([node.obj for node in response.context_data["sub_forums"].top_nodes]) == set(
-            [first_child, second_child]
-        )
-
-        # filtering on multiple tags is not supported yet
-        response = client.get(category_forum.get_absolute_url() + f"?forum_tag={tags[1]},{tags[2]}")
-        assert response.status_code == 200
-        assert set([node.obj for node in response.context_data["sub_forums"].top_nodes]) == set([])
+        sub_forums = [node.obj for node in response.context_data["sub_forums"].top_nodes]
+        assert sub_forums == expected
+        assert len(sub_forums) == sub_forums_count
 
     def test_show_subforum_tag(self, client, db, snapshot, reset_forum_sequence):
         category_forum = CategoryForumFactory(with_public_perms=True, for_snapshot=True)

--- a/lacommunaute/forum_conversation/enums.py
+++ b/lacommunaute/forum_conversation/enums.py
@@ -2,6 +2,6 @@ from django.db import models
 
 
 class Filters(models.TextChoices):
-    ALL = "ALL", "Les plus récentes"
-    NEW = "NEW", "En attente de réponse"
-    CERTIFIED = "CERTIFIED", "Réponse certifiée"
+    ALL = "ALL", "les plus récentes"
+    NEW = "NEW", "en attente de réponse"
+    CERTIFIED = "CERTIFIED", "avec une réponse certifiée"

--- a/lacommunaute/forum_conversation/factories.py
+++ b/lacommunaute/forum_conversation/factories.py
@@ -82,6 +82,13 @@ class TopicFactory(BaseTopicFactory):
             for tag in extracted:
                 self.tags.add(tag)
 
+    @factory.post_generation
+    def answered(self, create, extracted, **kwargs):
+        if not create or not extracted:
+            return
+
+        PostFactory(topic=self)
+
 
 class AnonymousTopicFactory(TopicFactory):
     poster = None

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -189,13 +189,7 @@
   </div>
   '''
 # ---
-# name: TestTopicListView.test_clickable_tags[10-?page=2-clickable_tags_page2][clickable_tags_page2]
-  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
-# ---
 # name: TestTopicListView.test_clickable_tags[10-query_param1-clickable_tags_page2][clickable_tags_page2]
-  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
-# ---
-# name: TestTopicListView.test_clickable_tags[None-None-clickable_tags_page1][clickable_tags_page1]
   '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
 # ---
 # name: TestTopicListView.test_clickable_tags[None-query_param0-clickable_tags_page1][clickable_tags_page1]
@@ -220,6 +214,44 @@
                               
                           </ul>
                       </div>
+  '''
+# ---
+# name: TestTopicListView.test_queryset_on_tag[-<lambda>-None][-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">2 questions</span>
+                      
+                  </div>
+  '''
+# ---
+# name: TestTopicListView.test_queryset_on_tag[buckley-<lambda>-<lambda>][buckley-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">1 question</span>
+                      
+                          <span class="fs-sm">
+                              sous l'étiquette
+                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
+                                  <i class="ri-close-fill ri-xs"></i>buckley
+                              </button>
+                          </span>
+                      
+                  </div>
+  '''
+# ---
+# name: TestTopicListView.test_queryset_on_tag[tag-<lambda>-<lambda>][tag-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">2 questions</span>
+                      
+                          <span class="fs-sm">
+                              sous l'étiquette
+                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
+                                  <i class="ri-close-fill ri-xs"></i>tag
+                              </button>
+                          </span>
+                      
+                  </div>
   '''
 # ---
 # name: test_breadcrumbs_on_topic_view[discussion_area_topic]
@@ -284,35 +316,5 @@
               
           </ol>
       </nav>
-  '''
-# ---
-# name: test_queryset_for_tagged_topic[1][1-tagged_topics]
-  '''
-  <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">1 question</span>
-                      
-                          <span class="fs-sm">
-                              sous l'étiquette
-                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
-                                  <i class="ri-close-fill ri-xs"></i>buckley
-                              </button>
-                          </span>
-                      
-                  </div>
-  '''
-# ---
-# name: test_queryset_for_tagged_topic[2][2-tagged_topics]
-  '''
-  <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">2 questions</span>
-                      
-                          <span class="fs-sm">
-                              sous l'étiquette
-                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
-                                  <i class="ri-close-fill ri-xs"></i>buckley
-                              </button>
-                          </span>
-                      
-                  </div>
   '''
 # ---

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -190,16 +190,10 @@
   '''
 # ---
 # name: TestTopicListView.test_clickable_tags[10-?page=2-clickable_tags_page2][clickable_tags_page2]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
+  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
 # ---
 # name: TestTopicListView.test_clickable_tags[None-None-clickable_tags_page1][clickable_tags_page1]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
-# ---
-# name: TestTopicListView.test_clickable_tags[clickable_tags_page1]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
-# ---
-# name: TestTopicListView.test_clickable_tags[clickable_tags_page2]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
+  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
 # ---
 # name: TestTopicListView.test_filter_dropdown_with_tags[filter_dropdown_with_tags]
   '''
@@ -207,15 +201,15 @@
                           <ul class="list-unstyled">
                               
                                   <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">Les plus récentes</button>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">Les plus récentes</button>
                                   </li>
                               
                                   <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=NEW&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">En attente de réponse</button>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=NEW&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">En attente de réponse</button>
                                   </li>
                               
                                   <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=CERTIFIED&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">Réponse certifiée</button>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=CERTIFIED&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">Réponse certifiée</button>
                                   </li>
                               
                           </ul>
@@ -289,36 +283,30 @@
 # name: test_queryset_for_tagged_topic[1][1-tagged_topics]
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">1 question
-                          avec l'étiquette buckley
-                      </span>
+                      <span class="h5 m-0">1 question</span>
+                      
+                          <span class="fs-sm">
+                              sous l'étiquette
+                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
+                                  <i class="ri-close-fill ri-xs"></i>buckley
+                              </button>
+                          </span>
+                      
                   </div>
   '''
 # ---
 # name: test_queryset_for_tagged_topic[2][2-tagged_topics]
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">2 questions
-                          avec l'étiquette buckley
-                      </span>
-                  </div>
-  '''
-# ---
-# name: test_queryset_for_tagged_topic[tagged_topic]
-  '''
-  <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">1 question
-                          avec l'étiquette buckley
-                      </span>
-                  </div>
-  '''
-# ---
-# name: test_queryset_for_tagged_topic[tagged_topics]
-  '''
-  <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">2 questions
-                          avec l'étiquette buckley
-                      </span>
+                      <span class="h5 m-0">2 questions</span>
+                      
+                          <span class="fs-sm">
+                              sous l'étiquette
+                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
+                                  <i class="ri-close-fill ri-xs"></i>buckley
+                              </button>
+                          </span>
+                      
                   </div>
   '''
 # ---

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -190,10 +190,10 @@
   '''
 # ---
 # name: TestTopicListView.test_clickable_tags[clickable_tags_page1]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tags=tag&amp;page=1">tag</a>'
+  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;page=1">tag</a>'
 # ---
 # name: TestTopicListView.test_clickable_tags[clickable_tags_page2]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tags=tag&amp;page=1">tag</a>'
+  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;page=1">tag</a>'
 # ---
 # name: test_breadcrumbs_on_topic_view[discussion_area_topic]
   '''

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -190,10 +190,31 @@
   '''
 # ---
 # name: TestTopicListView.test_clickable_tags[clickable_tags_page1]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;page=1">tag</a>'
+  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
 # ---
 # name: TestTopicListView.test_clickable_tags[clickable_tags_page2]
-  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;page=1">tag</a>'
+  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
+# ---
+# name: TestTopicListView.test_filter_dropdown_with_tags[filter_dropdown_with_tags]
+  '''
+  <div class="dropdown-menu dropdown-menu-end" id="filterTopicsDropdown">
+                          <ul class="list-unstyled">
+                              
+                                  <li>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">Les plus récentes</button>
+                                  </li>
+                              
+                                  <li>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=NEW&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">En attente de réponse</button>
+                                  </li>
+                              
+                                  <li>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=CERTIFIED&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">Réponse certifiée</button>
+                                  </li>
+                              
+                          </ul>
+                      </div>
+  '''
 # ---
 # name: test_breadcrumbs_on_topic_view[discussion_area_topic]
   '''

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -190,10 +190,16 @@
   '''
 # ---
 # name: TestTopicListView.test_clickable_tags[10-?page=2-clickable_tags_page2][clickable_tags_page2]
-  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
+  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
+# ---
+# name: TestTopicListView.test_clickable_tags[10-query_param1-clickable_tags_page2][clickable_tags_page2]
+  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
 # ---
 # name: TestTopicListView.test_clickable_tags[None-None-clickable_tags_page1][clickable_tags_page1]
-  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
+  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
+# ---
+# name: TestTopicListView.test_clickable_tags[None-query_param0-clickable_tags_page1][clickable_tags_page1]
+  '<button class="tag bg-info-lighter text-info matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?tag=tag&amp;filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filtertopics-button">tag</button>'
 # ---
 # name: TestTopicListView.test_filter_dropdown_with_tags[filter_dropdown_with_tags]
   '''
@@ -287,7 +293,7 @@
                       
                           <span class="fs-sm">
                               sous l'étiquette
-                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
+                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
                                   <i class="ri-close-fill ri-xs"></i>buckley
                               </button>
                           </span>
@@ -302,7 +308,7 @@
                       
                           <span class="fs-sm">
                               sous l'étiquette
-                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
+                              <button aria-label="Supprimer ce filtre" class="tag bg-info text-white matomo-event" data-bs-placement="top" data-bs-title="Supprimer ce filtre" data-bs-toggle="tooltip" data-matomo-action="unfilter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="unfilter-ontag-button">
                                   <i class="ri-close-fill ri-xs"></i>buckley
                               </button>
                           </span>

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -259,6 +259,24 @@
       </nav>
   '''
 # ---
+# name: test_queryset_for_tagged_topic[1][1-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">1 question
+                          avec l'étiquette buckley
+                      </span>
+                  </div>
+  '''
+# ---
+# name: test_queryset_for_tagged_topic[2][2-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">2 questions
+                          avec l'étiquette buckley
+                      </span>
+                  </div>
+  '''
+# ---
 # name: test_queryset_for_tagged_topic[tagged_topic]
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -201,15 +201,15 @@
                           <ul class="list-unstyled">
                               
                                   <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">Les plus récentes</button>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=ALL&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">les plus récentes</button>
                                   </li>
                               
                                   <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=NEW&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">En attente de réponse</button>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=NEW&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">en attente de réponse</button>
                                   </li>
                               
                                   <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=CERTIFIED&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">Réponse certifiée</button>
+                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=CERTIFIED&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">avec une réponse certifiée</button>
                                   </li>
                               
                           </ul>

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -216,10 +216,38 @@
                       </div>
   '''
 # ---
+# name: TestTopicListView.test_queryset_on_filter[ALL-<lambda>-None][ALL-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">2 questions</span>
+                      les plus récentes
+                      
+                  </div>
+  '''
+# ---
+# name: TestTopicListView.test_queryset_on_filter[CERTIFIED-<lambda>-<lambda>][CERTIFIED-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">1 question</span>
+                      avec une réponse certifiée
+                      
+                  </div>
+  '''
+# ---
+# name: TestTopicListView.test_queryset_on_filter[NEW-<lambda>-<lambda>][NEW-tagged_topics]
+  '''
+  <div class="flex-grow-1" id="topic-list-filter-header">
+                      <span class="h5 m-0">2 questions</span>
+                      en attente de réponse
+                      
+                  </div>
+  '''
+# ---
 # name: TestTopicListView.test_queryset_on_tag[-<lambda>-None][-tagged_topics]
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">
                       <span class="h5 m-0">2 questions</span>
+                      les plus récentes
                       
                   </div>
   '''
@@ -228,6 +256,7 @@
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">
                       <span class="h5 m-0">1 question</span>
+                      les plus récentes
                       
                           <span class="fs-sm">
                               sous l'étiquette
@@ -243,6 +272,7 @@
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">
                       <span class="h5 m-0">2 questions</span>
+                      les plus récentes
                       
                           <span class="fs-sm">
                               sous l'étiquette

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -189,6 +189,12 @@
   </div>
   '''
 # ---
+# name: TestTopicListView.test_clickable_tags[10-?page=2-clickable_tags_page2][clickable_tags_page2]
+  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
+# ---
+# name: TestTopicListView.test_clickable_tags[None-None-clickable_tags_page1][clickable_tags_page1]
+  '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
+# ---
 # name: TestTopicListView.test_clickable_tags[clickable_tags_page1]
   '<a class="tag bg-info-lighter text-info" href="/topics/?tag=tag&amp;filter=">tag</a>'
 # ---

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -787,14 +787,14 @@ def test_queryset_for_tagged_topic(client, db, snapshot):
     tagged_topic = TopicFactory(with_post=True, with_tags=tags)
     untagged_topic = TopicFactory(with_post=True)
 
-    response = client.get(reverse("forum_conversation_extension:topics"), {"tags": tags[0]})
+    response = client.get(reverse("forum_conversation_extension:topics"), {"tag": tags[0]})
     content = parse_response_to_soup(response, selector="#topic-list-filter-header")
     assert str(content) == snapshot(name="tagged_topic")
     assertContains(response, tagged_topic.subject)
     assertNotContains(response, untagged_topic.subject)
 
     TopicFactory(with_post=True, with_tags=tags)
-    response = client.get(reverse("forum_conversation_extension:topics"), {"tags": tags[0]})
+    response = client.get(reverse("forum_conversation_extension:topics"), {"tag": tags[0]})
     content = parse_response_to_soup(response, selector="#topic-list-filter-header")
     assert str(content) == snapshot(name="tagged_topics")
 

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -9,7 +9,7 @@ from django.utils.http import urlencode
 from faker import Faker
 from machina.core.db.models import get_model
 from machina.core.loading import get_class
-from pytest_django.asserts import assertContains, assertNotContains
+from pytest_django.asserts import assertContains
 from taggit.models import Tag
 
 from lacommunaute.forum.factories import CategoryForumFactory, ForumFactory
@@ -769,37 +769,6 @@ class TopicViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@pytest.fixture(name="topics_url")
-def fixture_topics_url():
-    return reverse("forum_conversation_extension:topics")
-
-
-@pytest.mark.parametrize("tag", ["lower", "UPPER"])
-def test_queryset_filtered_on_tag(client, db, tag, topics_url):
-    forum = ForumFactory(with_public_perms=True)
-    other_topic = TopicFactory(with_post=True, forum=forum)
-    tagged_topic = TopicFactory(with_post=True, forum=forum, with_tags=[tag])
-
-    response = client.get(topics_url, data={"tag": tag})
-    assert response.context_data["paginator"].count == 1
-    assertContains(response, tagged_topic.subject)
-    assertNotContains(response, other_topic.subject)
-
-
-@pytest.mark.parametrize("num_of_tagged_topics", [1, 2])
-def test_queryset_for_tagged_topic(client, db, num_of_tagged_topics, topics_url, snapshot):
-    tags = ["buckley", "jeff"]
-    tagged_topics = TopicFactory.create_batch(num_of_tagged_topics, with_post=True, with_tags=tags)
-    untagged_topic = TopicFactory(with_post=True)
-
-    response = client.get(topics_url, {"tag": tags[0]})
-    content = parse_response_to_soup(response, selector="#topic-list-filter-header")
-    assert str(content) == snapshot(name=f"{num_of_tagged_topics}-tagged_topics")
-    for tagged_topic in tagged_topics:
-        assertContains(response, tagged_topic.subject)
-    assertNotContains(response, untagged_topic.subject)
-
-
 def test_breadcrumbs_on_topic_view(client, db, snapshot):
     discussion_area_forum = ForumFactory(with_public_perms=True)
     category_forum = CategoryForumFactory(with_public_perms=True, with_child=True, name="D Category")
@@ -860,129 +829,9 @@ def test_breadcrumbs_on_topic_view(client, db, snapshot):
     assert str(content) == snapshot(name="discussion_area_topic")
 
 
-class TopicListViewTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.url = reverse("forum_conversation_extension:topics")
-        cls.forum = ForumFactory(with_public_perms=True)
-        cls.topic = TopicFactory(with_post=True, forum=cls.forum)
-        cls.user = cls.topic.poster
-
-    def test_context(self):
-        response = self.client.get(self.url)
-
-        self.assertIsInstance(response.context_data["form"], PostForm)
-        self.assertEqual(response.context_data["filters"], Filters.choices)
-        self.assertEqual(response.context_data["loadmoretopic_url"], reverse("forum_conversation_extension:topics"))
-        self.assertEqual(response.context_data["forum"], self.forum)
-        self.assertEqual(response.context_data["active_filter"], Filters.ALL)
-        self.assertEqual(list(response.context_data["active_tag"]), [])
-
-        for filter in Filters:
-            with self.subTest(filter=filter):
-                response = self.client.get(self.url + f"?filter={filter.value}")
-                self.assertEqual(
-                    response.context_data["loadmoretopic_url"],
-                    reverse("forum_conversation_extension:topics") + f"?filter={filter.value}",
-                )
-                self.assertEqual(response.context_data["active_filter"], filter)
-
-        response = self.client.get(self.url + "?filter=FAKE")
-        self.assertEqual(response.context_data["active_filter"], Filters.ALL)
-
-    def test_context_with_tag(self):
-        tags = [Tag.objects.create(name=faker.sentence()) for i in range(2)]
-        for tag in tags:
-            response = self.client.get(self.url, {"tag": tag.slug})
-            self.assertEqual(response.context_data["active_tag"], tag)
-
-    def test_queryset(self):
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context_data["paginator"].count, 1)
-
-        for topic in Topic.objects.exclude(id=self.topic.id):
-            with self.subTest(topic):
-                self.assertNotContains(response, topic.subject)
-
-        for topic in Topic.objects.filter(id=self.topic.id):
-            with self.subTest(topic):
-                self.assertContains(response, topic.subject)
-
-    def test_queryset_for_unanswered_topic(self):
-        # answered topic
-        PostFactory(topic=TopicFactory(with_post=True, forum=self.forum))
-        response = self.client.get(self.url + "?filter=NEW")
-        self.assertEqual(response.context_data["paginator"].count, 1)
-        self.assertContains(response, self.topic.subject, status_code=200)
-
-        for topic in Topic.objects.exclude(id=self.topic.id):
-            with self.subTest(topic):
-                self.assertNotContains(response, topic.subject)
-
-    def test_queryset_for_certified_topic(self):
-        certified_topic = TopicFactory(
-            with_post=True, with_certified_post=True, forum=ForumFactory(with_public_perms=True)
-        )
-
-        response = self.client.get(self.url + "?filter=CERTIFIED")
-        self.assertEqual(response.context_data["paginator"].count, 1)
-        self.assertContains(response, certified_topic.subject, status_code=200)
-        self.assertContains(response, certified_topic.certified_post.post.content.raw[:100])
-
-        for topic in Topic.objects.exclude(id=certified_topic.id):
-            with self.subTest(topic):
-                self.assertNotContains(response, topic.subject)
-
-    def test_pagination(self):
-        self.client.force_login(self.user)
-        TopicFactory.create_batch(9, with_post=True, forum=self.forum)
-
-        response = self.client.get(self.url)
-        self.assertNotContains(response, self.url + "?page=2", status_code=200)
-
-        TopicFactory(with_post=True, forum=self.forum)
-
-        response = self.client.get(self.url)
-        self.assertContains(response, self.url + "?page=2", status_code=200)
-
-    def test_showmoretopics_url_with_params(self):
-        tag_list = ["iae", "siae", "prescripteur"]
-        TopicFactory.create_batch(12, with_post=True, forum=self.forum, poster=self.user, with_tags=tag_list)
-        self.client.force_login(self.user)
-
-        params = [
-            {"filter": filter, "tags": tags}
-            for filter in ["ALL", "NEW", None]
-            for tags in tag_list + [",".join(tag_list), None]
-        ]
-
-        for param in params:
-            with self.subTest(param=param):
-                encoded_params = urlencode({k: v for k, v in param.items() if v})
-                url_with_params = self.url + f"?{encoded_params}" if encoded_params else self.url
-                expected_url = (
-                    url_with_params.replace("&", "&amp;") + "&amp;page=2" if encoded_params else self.url + "?page=2"
-                )
-                response = self.client.get(url_with_params)
-                self.assertContains(response, expected_url, status_code=200)
-
-    def test_filter_dropdown_visibility(self):
-        response = self.client.get(self.url)
-        self.assertContains(response, '<div class="dropdown-menu dropdown-menu-end" id="filterTopicsDropdown">')
-        self.assertEqual(response.context_data["filter_dropdown_endpoint"], self.url)
-
-        response = self.client.get(self.url + "?page=1")
-        self.assertNotContains(response, '<div class="dropdown-menu dropdown-menu-end" id="filterTopicsDropdown">')
-        self.assertEqual(response.context_data["filter_dropdown_endpoint"], None)
-
-    def test_template_name(self):
-        response = self.client.get(self.url)
-        self.assertTemplateUsed(response, "forum_conversation/topics_public.html")
-
-        response = self.client.get(self.url, **{"HTTP_HX_REQUEST": "true"})
-        self.assertTemplateUsed(response, "forum_conversation/topic_list.html")
+@pytest.fixture(name="topics_url")
+def fixture_topics_url():
+    return reverse("forum_conversation_extension:topics")
 
 
 @pytest.fixture(name="public_forum_with_topic")
@@ -993,9 +842,142 @@ def fixture_public_forum_with_topic(db):
 
 
 class TestTopicListView:
+    def test_context(self, client, topics_url, public_forum_with_topic):
+        response = client.get(topics_url)
+
+        assert isinstance(response.context["form"], PostForm)
+        assert response.context["filters"] == Filters.choices
+        assert response.context["loadmoretopic_url"], topics_url
+        assert response.context["forum"] == public_forum_with_topic
+        assert response.context["active_filter"] == Filters.ALL
+        assert list(response.context["active_tag"]) == []
+
+    @pytest.mark.parametrize("filter", Filters)
+    def test_context_on_filter(self, client, db, public_forum_with_topic, topics_url, filter):
+        response = client.get(topics_url, {"filter": filter.value})
+        assert response.context_data["active_filter"] == filter
+        assert response.context_data["loadmoretopic_url"] == f"{topics_url}?filter={filter.value}"
+
+    def test_context_on_tag(self, client, db, topics_url):
+        tag = Tag.objects.create(name="Carot Cake")
+        response = client.get(topics_url, {"tag": tag.slug})
+        assert response.context_data["active_tag"] == tag
+        assert response.context_data["loadmoretopic_url"] == f"{topics_url}?tag={tag.slug}"
+
+    @pytest.mark.parametrize("more_topics,pagination_is_visible", [(10, True), (9, False)])
+    def test_pagination(self, client, db, public_forum_with_topic, more_topics, pagination_is_visible, topics_url):
+        TopicFactory.create_batch(more_topics, with_post=True, forum=public_forum_with_topic)
+        response = client.get(topics_url)
+        assert bool(f"{topics_url}?page=2" in response.content.decode()) == pagination_is_visible
+
+    @pytest.mark.parametrize(
+        "filter,expected_topic,unexpected_topic",
+        [
+            ("ALL", lambda forum: TopicFactory(forum=forum, with_post=True), None),
+            (
+                "NEW",
+                lambda forum: TopicFactory(forum=forum, with_post=True),
+                lambda forum: TopicFactory(forum=forum, with_post=True, answered=True),
+            ),
+            (
+                "CERTIFIED",
+                lambda forum: TopicFactory(with_post=True, with_certified_post=True, forum=forum),
+                lambda forum: TopicFactory(forum=forum, with_post=True),
+            ),
+        ],
+    )
+    def test_queryset_on_filter(
+        self, client, db, public_forum_with_topic, topics_url, filter, expected_topic, unexpected_topic
+    ):
+        expected_topic = expected_topic(public_forum_with_topic)
+        if unexpected_topic:
+            unexpected_topic = unexpected_topic(public_forum_with_topic)
+
+        response = client.get(topics_url, {"filter": filter})
+        assert expected_topic in response.context["topics"]
+        if unexpected_topic:
+            assert unexpected_topic not in response.context["topics"]
+        if filter == "CERTIFIED":
+            assert expected_topic.certified_post.post.content.raw[:100] in response.content.decode()
+
+    @pytest.mark.parametrize(
+        "tag,expected_topic,unexpected_topic",
+        [
+            ("", lambda forum: TopicFactory(forum=forum, with_post=True), None),
+            (
+                "buckley",
+                lambda forum: TopicFactory(forum=forum, with_post=True, with_tags=["buckley"]),
+                lambda forum: TopicFactory(forum=forum, with_post=True),
+            ),
+            (
+                "tag",
+                lambda forum: TopicFactory(forum=forum, with_post=True, with_tags=["tag"]),
+                lambda forum: TopicFactory(forum=forum, with_post=True, with_tags=["other_tag"]),
+            ),
+        ],
+    )
+    def test_queryset_on_tag(
+        self, client, db, public_forum_with_topic, topics_url, tag, expected_topic, unexpected_topic, snapshot
+    ):
+        expected_topic = expected_topic(public_forum_with_topic)
+        if unexpected_topic:
+            unexpected_topic = unexpected_topic(public_forum_with_topic)
+
+        response = client.get(topics_url, {"tag": tag})
+        assert expected_topic in response.context["topics"]
+        if unexpected_topic:
+            assert unexpected_topic not in response.context["topics"]
+        content = parse_response_to_soup(response, selector="#topic-list-filter-header")
+        assert str(content) == snapshot(name=f"{tag}-tagged_topics")
+
+    @pytest.mark.parametrize(
+        "filter,tag", [("ALL", None), ("NEW", None), (None, None), ("ALL", "tag"), ("NEW", "tag"), (None, "tag")]
+    )
+    def test_showmoretopics_url_with_params(self, client, db, public_forum_with_topic, filter, tag, topics_url):
+        user = UserFactory()
+        topic_kwargs = {"with_post": True, "forum": public_forum_with_topic, "poster": user}
+        if tag:
+            topic_kwargs["with_tags"] = [tag]
+        TopicFactory.create_batch(12, **topic_kwargs)
+        client.force_login(user)
+
+        params = {"filter": filter, "tag": tag}
+        encoded_params = urlencode({k: v for k, v in params.items() if v})
+        url_with_params = f"{topics_url}?{encoded_params}" if encoded_params else topics_url
+        expected_url = (
+            f"{url_with_params.replace('&', '&amp;')}&amp;page=2" if encoded_params else f"{topics_url}?page=2"
+        )
+
+        response = client.get(url_with_params)
+        assertContains(response, expected_url, status_code=200)
+
+    @pytest.mark.parametrize("query_param,topics_url_visible", [({}, True), ({"page": 1}, False)])
+    def test_filter_dropdown_visibility(self, client, db, query_param, topics_url_visible, topics_url):
+        response = client.get(topics_url, query_param)
+        assert response.status_code == 200
+
+        content = parse_response_to_soup(response, selector="#topicsarea")
+        assert (
+            bool('<div class="dropdown-menu dropdown-menu-end" id="filterTopicsDropdown">' in str(content))
+            == topics_url_visible
+        )
+        assert bool(topics_url in str(content)) == topics_url_visible
+
+    @pytest.mark.parametrize(
+        "request_kwargs,template_name",
+        [
+            ({}, "forum_conversation/topics_public.html"),
+            ({"HTTP_HX_REQUEST": "true"}, "forum_conversation/topic_list.html"),
+        ],
+    )
+    def test_template_name(self, client, db, topics_url, request_kwargs, template_name):
+        response = client.get(topics_url, **request_kwargs)
+        assert response.status_code == 200
+        assert response.template_name == [template_name]
+
     @pytest.mark.parametrize(
         "num_of_topics_before_tagged_topic,query_param,snapshot_name",
-        [(None, None, "clickable_tags_page1"), (10, "?page=2", "clickable_tags_page2")],
+        [(None, {}, "clickable_tags_page1"), (10, {"page": 2}, "clickable_tags_page2")],
     )
     def test_clickable_tags(
         self, client, db, topics_url, num_of_topics_before_tagged_topic, query_param, snapshot_name, snapshot
@@ -1007,13 +989,12 @@ class TestTopicListView:
             # add 10 Topics before the tagged one to put it on the second page
             TopicFactory.create_batch(num_of_topics_before_tagged_topic, with_post=True, forum=forum)
 
-        url = topics_url + query_param if query_param else topics_url
-        response = client.get(url)
+        response = client.get(topics_url, query_param)
         assert response.status_code == 200
         assert str(parse_response_to_soup(response, selector="#filtertopics-button")) == snapshot(name=snapshot_name)
 
     def test_filter_dropdown_with_tags(self, client, db, public_forum_with_topic, topics_url, snapshot):
-        response = client.get(topics_url + "?tag=tag")
+        response = client.get(topics_url, {"tag": "tag"})
         content = parse_response_to_soup(response, selector="#filterTopicsDropdown")
         assert str(content) == snapshot(name="filter_dropdown_with_tags")
 

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -1010,7 +1010,7 @@ class TestTopicListView:
         url = topics_url + query_param if query_param else topics_url
         response = client.get(url)
         assert response.status_code == 200
-        assert str(parse_response_to_soup(response, selector="a.tag")) == snapshot(name=snapshot_name)
+        assert str(parse_response_to_soup(response, selector="#filtertopics-button")) == snapshot(name=snapshot_name)
 
     def test_filter_dropdown_with_tags(self, client, db, public_forum_with_topic, topics_url, snapshot):
         response = client.get(topics_url + "?tag=tag")

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -887,7 +887,7 @@ class TestTopicListView:
         ],
     )
     def test_queryset_on_filter(
-        self, client, db, public_forum_with_topic, topics_url, filter, expected_topic, unexpected_topic
+        self, client, db, public_forum_with_topic, topics_url, filter, expected_topic, unexpected_topic, snapshot
     ):
         expected_topic = expected_topic(public_forum_with_topic)
         if unexpected_topic:
@@ -899,6 +899,8 @@ class TestTopicListView:
             assert unexpected_topic not in response.context["topics"]
         if filter == "CERTIFIED":
             assert expected_topic.certified_post.post.content.raw[:100] in response.content.decode()
+        content = parse_response_to_soup(response, selector="#topic-list-filter-header")
+        assert str(content) == snapshot(name=f"{filter}-tagged_topics")
 
     @pytest.mark.parametrize(
         "tag,expected_topic,unexpected_topic",

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -875,20 +875,20 @@ class TopicListViewTest(TestCase):
         self.assertEqual(response.context_data["filters"], Filters.choices)
         self.assertEqual(response.context_data["loadmoretopic_url"], reverse("forum_conversation_extension:topics"))
         self.assertEqual(response.context_data["forum"], self.forum)
-        self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.ALL)
         self.assertEqual(list(response.context_data["active_tag"]), [])
 
-        for filter, label in Filters.choices:
-            with self.subTest(filter=filter, label=label):
-                response = self.client.get(self.url + f"?filter={filter}")
+        for filter in Filters:
+            with self.subTest(filter=filter):
+                response = self.client.get(self.url + f"?filter={filter.value}")
                 self.assertEqual(
                     response.context_data["loadmoretopic_url"],
-                    reverse("forum_conversation_extension:topics") + f"?filter={filter}",
+                    reverse("forum_conversation_extension:topics") + f"?filter={filter.value}",
                 )
-                self.assertEqual(response.context_data["active_filter_name"], label)
+                self.assertEqual(response.context_data["active_filter"], filter)
 
         response = self.client.get(self.url + "?filter=FAKE")
-        self.assertEqual(response.context_data["active_filter_name"], Filters.ALL.label)
+        self.assertEqual(response.context_data["active_filter"], Filters.ALL)
 
     def test_context_with_tag(self):
         tags = [Tag.objects.create(name=faker.sentence()) for i in range(2)]

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -782,21 +782,18 @@ def test_queryset_filtered_on_tag(client, db, tag):
     assertNotContains(response, other_topic.subject)
 
 
-def test_queryset_for_tagged_topic(client, db, snapshot):
+@pytest.mark.parametrize("num_of_tagged_topics", [1, 2])
+def test_queryset_for_tagged_topic(client, db, num_of_tagged_topics, snapshot):
     tags = ["buckley", "jeff"]
-    tagged_topic = TopicFactory(with_post=True, with_tags=tags)
+    tagged_topics = TopicFactory.create_batch(num_of_tagged_topics, with_post=True, with_tags=tags)
     untagged_topic = TopicFactory(with_post=True)
 
     response = client.get(reverse("forum_conversation_extension:topics"), {"tag": tags[0]})
     content = parse_response_to_soup(response, selector="#topic-list-filter-header")
-    assert str(content) == snapshot(name="tagged_topic")
-    assertContains(response, tagged_topic.subject)
+    assert str(content) == snapshot(name=f"{num_of_tagged_topics}-tagged_topics")
+    for tagged_topic in tagged_topics:
+        assertContains(response, tagged_topic.subject)
     assertNotContains(response, untagged_topic.subject)
-
-    TopicFactory(with_post=True, with_tags=tags)
-    response = client.get(reverse("forum_conversation_extension:topics"), {"tag": tags[0]})
-    content = parse_response_to_soup(response, selector="#topic-list-filter-header")
-    assert str(content) == snapshot(name="tagged_topics")
 
 
 def test_breadcrumbs_on_topic_view(client, db, snapshot):

--- a/lacommunaute/forum_conversation/view_mixins.py
+++ b/lacommunaute/forum_conversation/view_mixins.py
@@ -47,6 +47,6 @@ class FilteredTopicsListViewMixin:
 
         return {
             "active_tag": self.get_tag(),
-            "active_filter_name": getattr(Filters, active_filter, Filters.ALL).label,
+            "active_filter": getattr(Filters, active_filter, Filters.ALL),
             "filters": Filters.choices,
         }

--- a/lacommunaute/forum_conversation/view_mixins.py
+++ b/lacommunaute/forum_conversation/view_mixins.py
@@ -16,25 +16,21 @@ class FilteredTopicsListViewMixin:
         elif filter == Filters.CERTIFIED:
             qs = qs.filter(certified_post__isnull=False)
 
-        if self.get_tags():
-            qs = qs.filter(tags__in=self.get_tags())
+        if self.get_tag():
+            qs = qs.filter(tags=self.get_tag())
 
         return qs
 
-    def get_tags(self, flat=None):
-        if not hasattr(self, "tags"):
+    def get_tag(self):
+        if not hasattr(self, "tag"):
             try:
-                request_tags = self.request.GET["tags"]
+                request_tag = self.request.GET["tag"]
             except KeyError:
-                self.tags = Tag.objects.none()
+                self.tag = Tag.objects.none()
             else:
-                self.tags = Tag.objects.filter(slug__in=request_tags.lower().split(","))
+                self.tag = Tag.objects.filter(slug=request_tag.lower()).first()
 
-        if flat == "name":
-            return " ou ".join(tag.name for tag in self.tags)
-        if flat == "slug":
-            return ",".join(tag.slug for tag in self.tags)
-        return self.tags
+        return self.tag
 
     def get_load_more_url(self, url):
         """
@@ -50,8 +46,7 @@ class FilteredTopicsListViewMixin:
         active_filter = self.request.GET.get("filter", Filters.ALL)
 
         return {
-            "active_tags": self.get_tags(flat="slug"),
-            "active_tags_label": self.get_tags(flat="name"),
+            "active_tag": self.get_tag(),
             "active_filter_name": getattr(Filters, active_filter, Filters.ALL).label,
             "filters": Filters.choices,
         }

--- a/lacommunaute/templates/forum_conversation/partials/topic_filter.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_filter.html
@@ -4,9 +4,27 @@
         <div class="col-12 col-sm">
             <div class="d-flex align-items-center">
                 <div class="flex-grow-1" id="topic-list-filter-header">
-                    <span class="h5 m-0">{{ paginator.count }} question{{ paginator.count|pluralizefr }}
-                        {% if active_tag %}avec l'étiquette {{ active_tag.name|lower }}{% endif %}
-                    </span>
+                    <span class="h5 m-0">{{ paginator.count }} question{{ paginator.count|pluralizefr }}</span>
+                    {% if active_tag %}
+                        <span class="fs-sm">
+                            sous l'étiquette
+                            <button id="unfilter-ontag-button"
+                                    hx-target="#topicsarea"
+                                    hx-swap="outerHTML"
+                                    hx-push-url="true"
+                                    hx-get="{{ filter_dropdown_endpoint }}?filter={{ active_filter.name }}"
+                                    data-bs-toggle="tooltip"
+                                    data-bs-placement="top"
+                                    data-bs-title="Supprimer ce filtre"
+                                    aria-label="Supprimer ce filtre"
+                                    class="tag bg-info text-white matomo-event"
+                                    data-matomo-category="engagement"
+                                    data-matomo-action="unfilter"
+                                    data-matomo-option="topics">
+                                <i class="ri-close-fill ri-xs"></i>{{ active_tag.name|lower }}
+                            </button>
+                        </span>
+                    {% endif %}
                 </div>
                 <div>
                     <span class="fs-sm">Filtrer par :</span>
@@ -17,7 +35,7 @@
                         <ul class="list-unstyled">
                             {% for filter in filters %}
                                 <li>
-                                    <button id="filtertopics-button"
+                                    <button id="filter-ontag-button"
                                             hx-target="#topicsarea"
                                             hx-swap="outerHTML"
                                             hx-push-url="true"

--- a/lacommunaute/templates/forum_conversation/partials/topic_filter.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_filter.html
@@ -5,6 +5,7 @@
             <div class="d-flex align-items-center">
                 <div class="flex-grow-1" id="topic-list-filter-header">
                     <span class="h5 m-0">{{ paginator.count }} question{{ paginator.count|pluralizefr }}</span>
+                    {% if active_filter.name != filters.0.1 %}{{ active_filter.label|lower }}{% endif %}
                     {% if active_tag %}
                         <span class="fs-sm">
                             sous l'étiquette

--- a/lacommunaute/templates/forum_conversation/partials/topic_filter.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_filter.html
@@ -5,7 +5,7 @@
             <div class="d-flex align-items-center">
                 <div class="flex-grow-1" id="topic-list-filter-header">
                     <span class="h5 m-0">{{ paginator.count }} question{{ paginator.count|pluralizefr }}
-                        {% if active_tags %}avec l'étiquette {{ active_tags_label }}{% endif %}
+                        {% if active_tag %}avec l'étiquette {{ active_tag.name|lower }}{% endif %}
                     </span>
                 </div>
                 <div>
@@ -21,7 +21,7 @@
                                             hx-target="#topicsarea"
                                             hx-swap="outerHTML"
                                             hx-push-url="true"
-                                            hx-get="{{ filter_dropdown_endpoint }}?filter={{ filter.0 }}{% if active_tags %}&tags={{ active_tags }}{% endif %}"
+                                            hx-get="{{ filter_dropdown_endpoint }}?filter={{ filter.0 }}{% if active_tag %}&tag={{ active_tag.slug }}{% endif %}"
                                             class="dropdown-item matomo-event"
                                             data-matomo-category="engagement"
                                             data-matomo-action="filter"

--- a/lacommunaute/templates/forum_conversation/partials/topic_filter.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_filter.html
@@ -29,7 +29,7 @@
                 <div>
                     <span class="fs-sm">Filtrer par :</span>
                     <button type="button" class="btn btn-sm btn-link dropdown-toggle p-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="filterTopicsDropdown" aria-expanded="false">
-                        {{ active_filter_name }}
+                        {{ active_filter.label }}
                     </button>
                     <div class="dropdown-menu dropdown-menu-end" id="filterTopicsDropdown">
                         <ul class="list-unstyled">

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,5 +1,5 @@
 {% load url_add_query %}
 {% for tag in tags %}
-    {% url_add_query request.path tags=tag.slug page=1 as url_with_query_params %}
+    {% url_add_query request.path tag=tag.slug page=1 as url_with_query_params %}
     <a href="{{ url_with_query_params }}" class="tag bg-info-lighter text-info">{{ tag.name }}</a>
 {% endfor %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,5 +1,5 @@
 {% load url_add_query %}
 {% for tag in tags %}
-    {% url_add_query request.path tag=tag.slug page=1 as url_with_query_params %}
+    {% url_add_query request.path tag=tag.slug filter=active_filter.value as url_with_query_params %}
     <a href="{{ url_with_query_params }}" class="tag bg-info-lighter text-info">{{ tag.name }}</a>
 {% endfor %}

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,5 +1,13 @@
 {% load url_add_query %}
 {% for tag in tags %}
     {% url_add_query request.path tag=tag.slug filter=active_filter.value as url_with_query_params %}
-    <a href="{{ url_with_query_params }}" class="tag bg-info-lighter text-info">{{ tag.name }}</a>
+    <button id="filtertopics-button"
+            hx-target="#topicsarea"
+            hx-swap="outerHTML"
+            hx-push-url="true"
+            hx-get="{{ url_with_query_params }}"
+            class="tag bg-info-lighter text-info matomo-event"
+            data-matomo-category="engagement"
+            data-matomo-action="filter"
+            data-matomo-option="topics">{{ tag.name }}</button>
 {% endfor %}

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -9,7 +9,7 @@
     {% get_permission 'can_download_files' forum request.user as user_can_download_files %}
 {% endif %}
 <div id="topicsarea">
-    {% include "forum_conversation/partials/topic_filter.html" with active_tags=active_tags %}
+    {% include "forum_conversation/partials/topic_filter.html" with active_tag=active_tag %}
     {% if topics or not hide_if_empty %}
         {% for topic in topics %}
             <div class="row">

--- a/lacommunaute/templates/forum_conversation/topics_public.html
+++ b/lacommunaute/templates/forum_conversation/topics_public.html
@@ -35,7 +35,7 @@
                 <div class="s-section__col col-12">
                     <div class="c-box">
                         {% with topics=topics %}
-                            {% include "forum_conversation/topic_list.html" with active_tags=active_tags %}
+                            {% include "forum_conversation/topic_list.html" with active_tag=active_tag %}
                         {% endwith %}
                     </div>
                 </div>


### PR DESCRIPTION
🦺 suite #794. fusion avant d'avoir poussé le rebasage