### PR TITLE
fix(attachment): affichage des liens vers les fichiers des messages

### DIFF
--- a/lacommunaute/utils/templatetags/attachments_tags.py
+++ b/lacommunaute/utils/templatetags/attachments_tags.py
@@ -17,4 +17,8 @@ def is_image(object):
 
 @register.filter
 def is_available(object):
-    return object.file.field.storage.exists(object.file.name)
+    try:
+        object.file.size
+    except FileNotFoundError:
+        return False
+    return True

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -106,7 +106,7 @@ class AttachmentsTemplateTagTests(TestCase):
         f = SimpleUploadedFile("test.png", force_bytes("file_content"))
         attachment = AttachmentFactory(post=self.post, file=f)
 
-        with patch.object(default_storage, "exists", return_value=False):
+        with patch.object(default_storage, "size", side_effect=FileNotFoundError):
             out = Template("{% load attachments_tags %}" "{{ attachment|is_available }}").render(
                 Context(
                     {


### PR DESCRIPTION
## Description

🎸 Le templatetag `is_available` retourne à tord que le fichier n'est pas disponible.
🎸 Remplacer le test par la recherche de la taille du fichier, assorti  d'un `try/except` si le fichier n'est pas trouvé

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 pourquoi  `object.file.field.storage.exists(object.file.name)` ne fonctionne pas ou plus ???

### Captures d'écran (optionnel)

état actuel non désiré (https://communaute.inclusion.beta.gouv.fr/forum/espace-d%C3%A9changes-113/topic/passage-de-titre-cip-2168/)

![image](https://github.com/user-attachments/assets/ef4da74d-df14-44f7-9b7f-022320c57275)

état desiré

![image](https://github.com/user-attachments/assets/66e024d9-5253-42c4-b89f-5dfeca8d92e9)
