### PR TITLE
feat(stats): ajout de la colonne categorie dans les stats des fiches pratiques

### DIFF
--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -58,6 +58,13 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
                                                   <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       <i class="ri-arrow-down-s-fill"></i>
@@ -96,6 +103,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 40min</td>
                                           <td>70</td>
                                           <td>2</td>
@@ -108,6 +116,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 30min</td>
                                           <td>100</td>
                                           <td>1</td>
@@ -120,6 +129,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 20min</td>
                                           <td>90</td>
                                           <td>4</td>
@@ -132,6 +142,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 10min</td>
                                           <td>80</td>
                                           <td>3</td>
@@ -197,6 +208,13 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
                                                   <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       
@@ -235,6 +253,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 10min</td>
                                           <td>80</td>
                                           <td>3</td>
@@ -247,6 +266,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 40min</td>
                                           <td>70</td>
                                           <td>2</td>
@@ -259,6 +279,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 30min</td>
                                           <td>100</td>
                                           <td>1</td>
@@ -271,6 +292,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 20min</td>
                                           <td>90</td>
                                           <td>4</td>
@@ -336,6 +358,13 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
                                                   <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       
@@ -374,6 +403,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 20min</td>
                                           <td>90</td>
                                           <td>4</td>
@@ -386,6 +416,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 10min</td>
                                           <td>80</td>
                                           <td>3</td>
@@ -398,6 +429,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 40min</td>
                                           <td>70</td>
                                           <td>2</td>
@@ -410,6 +442,157 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
+                                          <td>0h 30min</td>
+                                          <td>100</td>
+                                          <td>1</td>
+                                          <td>3,00</td>
+                                      </tr>
+                                  
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestForumStatView.test_sort_key[parent-sort_by_parent][sort_by_parent]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+      <div class="container">
+          <nav aria-label="Fil d'ariane" class="c-breadcrumb">
+              <ol class="breadcrumb">
+                  <li class="breadcrumb-item">Retourner vers</li>
+                  <li class="breadcrumb-item">
+                      <a href="/statistiques/">Statistiques</a>
+                  </li>
+              </ol>
+          </nav>
+      </div>
+  
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1 class="s-title-01__title h1">Statistiques des fiches pratiques</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row" id="most_rated">
+                  <div class="s-section__col col-12">
+                      <div class="c-box mb-3 mb-md-5">
+                          <table class="table">
+                              <caption>Sont présentes dans ce tableau, les fiches pratiques de l'espace Documents.
+                                  <br/>
+                                  Le nombre et la moyenne des notations sont calculés en temps réel.
+                                  <br/>
+                                  Le nombre de visites et le cumul du temps de lecture est calculé hebdomadairement, chaque lundi matin.
+                              </caption>
+                              
+                                  <thead>
+                                      <tr>
+                                          <th scope="col">Fiche Pratique</th>
+                                          
+                                              <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      <i class="ri-arrow-down-s-fill"></i>
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
+                                                      Temps de lecture
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_visits">
+                                                      Nombre de Visites
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=count_rating">
+                                                      Nombres de notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=avg_rating">
+                                                      Moyenne des notations
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                      </tr>
+                                  </thead>
+                              
+                              <tbody>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">C</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>category B</td>
+                                          <td>0h 20min</td>
+                                          <td>90</td>
+                                          <td>4</td>
+                                          <td>2,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">D</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>category B</td>
+                                          <td>0h 10min</td>
+                                          <td>80</td>
+                                          <td>3</td>
+                                          <td>5,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">A</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>category A</td>
+                                          <td>0h 40min</td>
+                                          <td>70</td>
+                                          <td>2</td>
+                                          <td>4,00</td>
+                                      </tr>
+                                  
+                                      <tr>
+                                          <th scope="row">
+                                              <a href="">B</a>
+                                              <br/>
+                                              
+                                          </th>
+                                          <td>category A</td>
                                           <td>0h 30min</td>
                                           <td>100</td>
                                           <td>1</td>
@@ -475,6 +658,13 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
                                                   <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       <i class="ri-arrow-down-s-fill"></i>
@@ -513,6 +703,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 40min</td>
                                           <td>70</td>
                                           <td>2</td>
@@ -525,6 +716,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 30min</td>
                                           <td>100</td>
                                           <td>1</td>
@@ -537,6 +729,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 20min</td>
                                           <td>90</td>
                                           <td>4</td>
@@ -549,6 +742,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 10min</td>
                                           <td>80</td>
                                           <td>3</td>
@@ -614,6 +808,13 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
                                                   <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       
@@ -652,6 +853,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 30min</td>
                                           <td>100</td>
                                           <td>1</td>
@@ -664,6 +866,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 20min</td>
                                           <td>90</td>
                                           <td>4</td>
@@ -676,6 +879,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 10min</td>
                                           <td>80</td>
                                           <td>3</td>
@@ -688,6 +892,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 40min</td>
                                           <td>70</td>
                                           <td>2</td>
@@ -753,6 +958,13 @@
                                           <th scope="col">Fiche Pratique</th>
                                           
                                               <th scope="col">
+                                                  <a class="text-decoration-none" href="/statistiques/documents/?sort=parent">
+                                                      Catégorie
+                                                      
+                                                  </a>
+                                              </th>
+                                          
+                                              <th scope="col">
                                                   <a class="text-decoration-none" href="/statistiques/documents/?sort=sum_time_spent">
                                                       Temps de lecture
                                                       <i class="ri-arrow-down-s-fill"></i>
@@ -791,6 +1003,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 40min</td>
                                           <td>70</td>
                                           <td>2</td>
@@ -803,6 +1016,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category A</td>
                                           <td>0h 30min</td>
                                           <td>100</td>
                                           <td>1</td>
@@ -815,6 +1029,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 20min</td>
                                           <td>90</td>
                                           <td>4</td>
@@ -827,6 +1042,7 @@
                                               <br/>
                                               
                                           </th>
+                                          <td>category B</td>
                                           <td>0h 10min</td>
                                           <td>80</td>
                                           <td>3</td>

--- a/lacommunaute/stats/views.py
+++ b/lacommunaute/stats/views.py
@@ -182,6 +182,7 @@ class DocumentStatsView(View):
 
     def get_sort_fields(self):
         return [
+            {"key": "parent", "label": "Catégorie"},
             {"key": "sum_time_spent", "label": "Temps de lecture"},
             {"key": "sum_visits", "label": "Nombre de Visites"},
             {"key": "count_rating", "label": "Nombres de notations"},

--- a/lacommunaute/templates/stats/documents.html
+++ b/lacommunaute/templates/stats/documents.html
@@ -62,6 +62,7 @@
                                             <br>
                                             {% if obj.partner %}<span class="text-muted">en partenariat avec {{ obj.partner.name }}</span>{% endif %}
                                         </th>
+                                        <td>{{ obj.parent }}</td>
                                         <td>{{ obj.sum_time_spent|convert_seconds_into_hours }}</td>
                                         <td>{{ obj.sum_visits }}</td>
                                         <td>{{ obj.count_rating|default_if_none:"pas de notation" }}</td>


### PR DESCRIPTION
## Description

🎸 La catégorie est le `Forum` parent. Ajout en colonne + tri dessus

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).


### Captures d'écran (optionnel)

non trié

![image](https://github.com/user-attachments/assets/af3f3b7c-7cdb-416c-9ec6-913dd8e088dc)


trié

![image](https://github.com/user-attachments/assets/a7eea47c-db5d-43a7-949e-5db777271daf)
