### PR TITLE
chore: supprimer les balises `#noqa` dans les fichiers de tests

### DIFF
--- a/lacommunaute/forum/tests/test_categoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_categoryforum_createview.py
@@ -1,8 +1,7 @@
-import pytest  # noqa
 from django.urls import reverse
-
 from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains
+
 from lacommunaute.forum.models import Forum
 from lacommunaute.users.factories import UserFactory
 

--- a/lacommunaute/forum/tests/test_categoryforum_listview.py
+++ b/lacommunaute/forum/tests/test_categoryforum_listview.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
 

--- a/lacommunaute/forum/tests/test_forum_rating_view.py
+++ b/lacommunaute/forum/tests/test_forum_rating_view.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 from django.urls import reverse
 
 from lacommunaute.forum.factories import ForumFactory

--- a/lacommunaute/forum/tests/test_forum_updateview.py
+++ b/lacommunaute/forum/tests/test_forum_updateview.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-import pytest  # noqa
+import pytest
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse

--- a/lacommunaute/forum/tests/test_subcategoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_subcategoryforum_createview.py
@@ -1,11 +1,10 @@
-import pytest  # noqa
 from django.urls import reverse
 from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains
 
+from lacommunaute.forum.factories import CategoryForumFactory
 from lacommunaute.forum.models import Forum
 from lacommunaute.users.factories import UserFactory
-from lacommunaute.forum.factories import CategoryForumFactory
 
 
 UserForumPermission = get_model("forum_permission", "UserForumPermission")

--- a/lacommunaute/forum/tests/test_subcategoryforum_listview.py
+++ b/lacommunaute/forum/tests/test_subcategoryforum_listview.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 from django.urls import reverse
 
 from lacommunaute.forum.factories import CategoryForumFactory, ForumFactory

--- a/lacommunaute/forum/tests/tests_forms.py
+++ b/lacommunaute/forum/tests/tests_forms.py
@@ -1,6 +1,3 @@
-import pytest  # noqa
-
-
 from lacommunaute.forum.forms import ForumForm
 from lacommunaute.forum.models import Forum
 

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -1,6 +1,6 @@
 import re
 
-import pytest  # noqa
+import pytest
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.template.defaultfilters import truncatechars_html

--- a/lacommunaute/forum_conversation/tests/tests_forms.py
+++ b/lacommunaute/forum_conversation/tests/tests_forms.py
@@ -1,9 +1,10 @@
-import pytest  # noqa
+import pytest
 from django.conf import settings
 from django.forms import HiddenInput
 from django.test import TestCase
 from django.urls import reverse
 from faker import Faker
+from taggit.models import Tag
 
 from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import (
@@ -15,7 +16,6 @@ from lacommunaute.forum_conversation.factories import (
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.users.factories import UserFactory
-from taggit.models import Tag
 
 
 faker = Faker(settings.LANGUAGE_CODE)

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 from django.conf import settings
 from django.contrib.messages.api import get_messages
 from django.contrib.messages.middleware import MessageMiddleware

--- a/lacommunaute/forum_member/tests/tests_models.py
+++ b/lacommunaute/forum_member/tests/tests_models.py
@@ -1,11 +1,3 @@
-import pytest  # noqa
-
-from lacommunaute.forum_conversation.factories import (  # noqa
-    AnonymousPostFactory,
-    AnonymousTopicFactory,
-    PostFactory,
-    TopicFactory,
-)
 from lacommunaute.forum_member.factories import ForumProfileFactory
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 

--- a/lacommunaute/forum_moderation/tests/test_moderation_queue_detail_view.py
+++ b/lacommunaute/forum_moderation/tests/test_moderation_queue_detail_view.py
@@ -1,10 +1,8 @@
-import pytest  # noqa
-
-from lacommunaute.forum_conversation.factories import TopicFactory, AnonymousPostFactory
-from lacommunaute.users.factories import UserFactory
-
 from django.urls import reverse
 from pytest_django.asserts import assertContains
+
+from lacommunaute.forum_conversation.factories import AnonymousPostFactory, TopicFactory
+from lacommunaute.users.factories import UserFactory
 
 
 def test_detail_view_for_anonymous_post(client, db):

--- a/lacommunaute/forum_moderation/tests/test_post_disapprove_view.py
+++ b/lacommunaute/forum_moderation/tests/test_post_disapprove_view.py
@@ -1,13 +1,11 @@
-import pytest  # noqa
-
 from django.urls import reverse
 
-from lacommunaute.forum_conversation.factories import TopicFactory, AnonymousPostFactory
+from lacommunaute.forum_conversation.factories import AnonymousPostFactory, TopicFactory
 from lacommunaute.forum_conversation.models import Post
-from lacommunaute.forum_moderation.models import BlockedEmail, BlockedPost
-from lacommunaute.users.factories import UserFactory
 from lacommunaute.forum_moderation.enums import BlockedPostReason
 from lacommunaute.forum_moderation.factories import BlockedEmailFactory
+from lacommunaute.forum_moderation.models import BlockedEmail, BlockedPost
+from lacommunaute.users.factories import UserFactory
 
 
 def test_post_disapprove_view(client, db):

--- a/lacommunaute/forum_moderation/tests/test_utils.py
+++ b/lacommunaute/forum_moderation/tests/test_utils.py
@@ -1,9 +1,9 @@
-import pytest  # noqa
-
 from faker import Faker
+
 from lacommunaute.forum_conversation.factories import AnonymousPostFactory, TopicFactory
-from lacommunaute.forum_moderation.utils import check_post_approbation
 from lacommunaute.forum_moderation.factories import BlockedDomainNameFactory, BlockedEmailFactory
+from lacommunaute.forum_moderation.utils import check_post_approbation
+
 
 faker = Faker()
 

--- a/lacommunaute/forum_upvote/tests/test_forumupvoteview.py
+++ b/lacommunaute/forum_upvote/tests/test_forumupvoteview.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.urls import reverse
 from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains

--- a/lacommunaute/forum_upvote/tests/test_postupvoteview.py
+++ b/lacommunaute/forum_upvote/tests/test_postupvoteview.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from machina.core.db.models import get_model

--- a/lacommunaute/forum_upvote/tests/test_upvotelistview.py
+++ b/lacommunaute/forum_upvote/tests/test_upvotelistview.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertTemplateUsed
 

--- a/lacommunaute/pages/tests/test_homepage.py
+++ b/lacommunaute/pages/tests/test_homepage.py
@@ -1,6 +1,5 @@
 import re
 
-import pytest  # noqa
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from django.utils import timezone

--- a/lacommunaute/pages/tests/test_mentions_legales.py
+++ b/lacommunaute/pages/tests/test_mentions_legales.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 

--- a/lacommunaute/pages/tests/test_politique_confidentialite.py
+++ b/lacommunaute/pages/tests/test_politique_confidentialite.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 

--- a/lacommunaute/partner/tests/tests_forms.py
+++ b/lacommunaute/partner/tests/tests_forms.py
@@ -1,5 +1,3 @@
-import pytest  # noqa
-
 from lacommunaute.partner.forms import PartnerForm
 from lacommunaute.partner.models import Partner
 

--- a/lacommunaute/partner/tests/tests_model.py
+++ b/lacommunaute/partner/tests/tests_model.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 from django.conf import settings
 from django.db import IntegrityError
 

--- a/lacommunaute/partner/tests/tests_partner_createview.py
+++ b/lacommunaute/partner/tests/tests_partner_createview.py
@@ -1,9 +1,8 @@
-import pytest  # noqa
-
+import pytest
 from django.urls import reverse
 
-from lacommunaute.users.factories import UserFactory
 from lacommunaute.partner.models import Partner
+from lacommunaute.users.factories import UserFactory
 
 
 @pytest.fixture(name="url")

--- a/lacommunaute/partner/tests/tests_partner_detailview.py
+++ b/lacommunaute/partner/tests/tests_partner_detailview.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 
 from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.partner.factories import PartnerFactory

--- a/lacommunaute/partner/tests/tests_partner_listview.py
+++ b/lacommunaute/partner/tests/tests_partner_listview.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 from django.urls import reverse
 
 from lacommunaute.partner.factories import PartnerFactory

--- a/lacommunaute/partner/tests/tests_partner_updateview.py
+++ b/lacommunaute/partner/tests/tests_partner_updateview.py
@@ -1,5 +1,4 @@
-import pytest  # noqa
-
+import pytest
 from django.urls import reverse
 
 from lacommunaute.partner.factories import PartnerFactory

--- a/lacommunaute/stats/tests/tests_management_commands.py
+++ b/lacommunaute/stats/tests/tests_management_commands.py
@@ -1,8 +1,9 @@
-import pytest  # noqa
-from lacommunaute.stats.management.commands.collect_matomo_stats import get_initial_from_date
+import pytest
 from django.core.management import call_command
-from lacommunaute.surveys.factories import DSPFactory
+
 from lacommunaute.stats.factories import StatFactory
+from lacommunaute.stats.management.commands.collect_matomo_stats import get_initial_from_date
+from lacommunaute.surveys.factories import DSPFactory
 
 
 def test_collect_django_stats(db, capsys):

--- a/lacommunaute/stats/tests/tests_models.py
+++ b/lacommunaute/stats/tests/tests_models.py
@@ -1,4 +1,4 @@
-import pytest  # noqa
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.db import IntegrityError
 from django.test import TestCase

--- a/lacommunaute/stats/tests/tests_views.py
+++ b/lacommunaute/stats/tests/tests_views.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-import pytest  # noqa
+import pytest
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 from django.urls import reverse

--- a/lacommunaute/surveys/tests/test_stats.py
+++ b/lacommunaute/surveys/tests/test_stats.py
@@ -1,6 +1,7 @@
-import pytest  # noqa
-from datetime import datetime, date
+from datetime import date, datetime
+
 from dateutil.relativedelta import relativedelta
+
 from lacommunaute.stats.models import Stat
 from lacommunaute.surveys.factories import DSPFactory
 from lacommunaute.surveys.stats import collect_dsp_stats

--- a/lacommunaute/surveys/tests/test_views.py
+++ b/lacommunaute/surveys/tests/test_views.py
@@ -1,4 +1,3 @@
-import pytest  # noqa
 from django.test import override_settings
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains


### PR DESCRIPTION
## Description

🎸 cf titre, puis executer un `make fix`

## Type de changement

🚧 technique