### PR TITLE
chore: suppression de mailhog (dev)

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -49,14 +49,6 @@ DEBUG_TOOLBAR_CONFIG = {
     "SHOW_TEMPLATE_CONTEXT": True,
 }
 
-# Emails in Mailhog
-# ------------------------------------------------------------------------------
-EMAIL_HOST = "0.0.0.0"
-EMAIL_PORT = 1025
-EMAIL_HOST_USER = ""
-EMAIL_HOST_PASSWORD = ""
-EMAIL_USE_TLS = False
-
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"  # noqa: F405
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,14 +55,6 @@ services:
       - "127.0.0.1:${DJANGO_PORT_ON_DOCKER_HOST:-8000}:8000"
       - "127.0.0.1:${DJANGO_DEBUGPY_PORT:-5678}:5678"
 
-  mailhog:
-    profiles: [ "mailhog" ]
-    image: mailhog/mailhog:latest
-    restart: always
-    ports:
-      - 127.0.0.1:1025:1025
-      - 127.0.0.1:8025:8025
-
 volumes:
   postgres_data:
   postgres_data_backups:


### PR DESCRIPTION
## Description

🎸 mailhog devient inutile en env de dev avec le deploiement de la #731 

## Type de changement

🚧 technique

