### PR TITLE
fix(stats): ajout des liens vers les forums dans la page de statistique des fiches pratiques

### DIFF
--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -99,7 +99,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -112,7 +112,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -125,7 +125,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -138,7 +138,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>
@@ -249,7 +249,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>
@@ -262,7 +262,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -275,7 +275,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -288,7 +288,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -399,7 +399,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -412,7 +412,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>
@@ -425,7 +425,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -438,7 +438,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -549,7 +549,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -562,7 +562,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>
@@ -575,7 +575,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -588,7 +588,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -699,7 +699,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -712,7 +712,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -725,7 +725,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -738,7 +738,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>
@@ -849,7 +849,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -862,7 +862,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -875,7 +875,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>
@@ -888,7 +888,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -999,7 +999,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">A</a>
+                                              <a href="/forum/a-[PK of Forum]/">A</a>
                                               <br/>
                                               
                                           </th>
@@ -1012,7 +1012,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">B</a>
+                                              <a href="/forum/b-[PK of Forum]/">B</a>
                                               <br/>
                                               
                                           </th>
@@ -1025,7 +1025,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">C</a>
+                                              <a href="/forum/c-[PK of Forum]/">C</a>
                                               <br/>
                                               
                                           </th>
@@ -1038,7 +1038,7 @@
                                   
                                       <tr>
                                           <th scope="row">
-                                              <a href="">D</a>
+                                              <a href="/forum/d-[PK of Forum]/">D</a>
                                               <br/>
                                               
                                           </th>

--- a/lacommunaute/templates/stats/documents.html
+++ b/lacommunaute/templates/stats/documents.html
@@ -58,7 +58,7 @@
                                 {% for obj in objects %}
                                     <tr>
                                         <th scope="row">
-                                            <a href="{{ obj.absolute_url }}">{{ obj.name }}</a>
+                                            <a href="{{ obj.get_absolute_url }}">{{ obj.name }}</a>
                                             <br>
                                             {% if obj.partner %}<span class="text-muted">en partenariat avec {{ obj.partner.name }}</span>{% endif %}
                                         </th>


### PR DESCRIPTION
## Description

🎸 lien cassé vers les forums, colonne "fiche pratique"

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 forum.get_absolute_url

### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/16db1200-4e16-4c9d-baee-833902a60c4d)
