### PR TITLE
chore: login in debug/dev mode

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,6 +3,8 @@ import os
 from dotenv import load_dotenv
 from machina import MACHINA_MAIN_STATIC_DIR, MACHINA_MAIN_TEMPLATE_DIR
 
+from lacommunaute.utils.enums import Environment
+
 
 load_dotenv()
 
@@ -17,6 +19,8 @@ APPS_DIR = os.path.abspath(os.path.join(ROOT_DIR, "lacommunaute"))
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
+ENVIRONMENT = Environment.PROD
+
 PARKING_PAGE = os.getenv("PARKING_PAGE", "False") == "True"
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "communaute.inclusion.beta.gouv.fr,").split(",")

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,6 +1,8 @@
 # Enable django-debug-toolbar with Docker.
 import socket
 
+from lacommunaute.utils.enums import Environment
+
 from .base import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F403 F401
 
 
@@ -10,6 +12,7 @@ SECRET_KEY = "foobar"
 
 
 DEBUG = True
+ENVIRONMENT = Environment.DEV
 
 ALLOWED_HOSTS = ["localhost", "0.0.0.0", "127.0.0.1", "192.168.0.1"]
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -49,9 +49,6 @@ urlpatterns = [
     path("tracking/", include(tracking_urlpatterns_factory.urlpatterns)),
 ]
 
-if settings.DEBUG is True:
-    urlpatterns += [path("", include("django.contrib.auth.urls"))]
-
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns += [

--- a/lacommunaute/templates/layouts/base.html
+++ b/lacommunaute/templates/layouts/base.html
@@ -69,6 +69,7 @@
             {% include "partials/header.html" %}
         {% endblock %}
         {% block sub_header %}{% endblock %}
+        {% if ENVIRONMENT != "PROD" %}<div id="debug-mode-banner" class="bg-danger text-white mt-3">DEV MODE</div>{% endif %}
         <main id="main" role="main" class="s-main">
             {% block messages %}
                 {% if messages %}

--- a/lacommunaute/users/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/users/tests/__snapshots__/tests_views.ambr
@@ -527,6 +527,9 @@
           </main>
   '''
 # ---
-# name: TestSendMagicLink.test_send_magic_link[send_magic_link_payload]
-  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.beta.gouv.fr"}, "to": [{"email": "edith@martin.co"}], "params": {"display_name": "Edith M.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
+# name: TestSendMagicLink.test_send_magic_link[DEV-1][send_magic_link_payload]
+  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.beta.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
+# ---
+# name: TestSendMagicLink.test_send_magic_link[PROD-0][send_magic_link_payload]
+  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.beta.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
 # ---

--- a/lacommunaute/utils/enums.py
+++ b/lacommunaute/utils/enums.py
@@ -4,3 +4,8 @@ from django.db import models
 class PeriodAggregation(models.TextChoices):
     MONTH = "MONTH"
     WEEK = "WEEK"
+
+
+class Environment(models.TextChoices):
+    DEV = "DEV"
+    PROD = "PROD"

--- a/lacommunaute/utils/settings_context_processors.py
+++ b/lacommunaute/utils/settings_context_processors.py
@@ -12,4 +12,5 @@ def expose_settings(request):
         "BASE_TEMPLATE": base_template,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
+        "ENVIRONMENT": settings.ENVIRONMENT,
     }

--- a/lacommunaute/utils/tests/tests_middleware.py
+++ b/lacommunaute/utils/tests/tests_middleware.py
@@ -1,4 +1,7 @@
+import pytest
 from django.test import TestCase, override_settings
+
+from lacommunaute.utils.enums import Environment
 
 
 class ParkingMiddlewareTest(TestCase):
@@ -13,3 +16,17 @@ class ParkingMiddlewareTest(TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "pages/home.html")
+
+
+class TestEnvironmentSettingsMiddleware:
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            (Environment.PROD, False),
+            (Environment.DEV, True),
+        ],
+    )
+    def test_prod_environment(self, client, db, env, expected):
+        with override_settings(ENVIRONMENT=env):
+            response = client.get("/")
+        assert ('id="debug-mode-banner"' in response.content.decode()) == expected

--- a/lacommunaute/utils/tests/tests_urls.py
+++ b/lacommunaute/utils/tests/tests_urls.py
@@ -13,15 +13,8 @@ def _clear_url_caches():
     sys.modules.pop("config.urls", None)
 
 
-def test_django_urls_dev(settings):
-    settings.DEBUG = True
-    assert reverse("login") == "/login/"
-
-
 def test_django_urls_prod(settings):
     settings.DEBUG = False
-    with pytest.raises(NoReverseMatch):
-        reverse("login")
     with pytest.raises(NoReverseMatch):
         reverse("djdt:render_panel")
 


### PR DESCRIPTION
## Description

🎸 lorsque le mode DEBUG est actif:
* afficher le lien magique de connexion au lieu d'utiliser les routes `django.contrib.auth.urls`
* afficher une bannière rouge

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique

### Points d'attention

🦺 passage de la valeur de la variable `DEBUG` dans le `context_processor`

### Captures d'écran (optionnel)

Banniere Debug Mode

![image](https://github.com/user-attachments/assets/bdeb154d-7ec3-4339-8017-727a313967dc)

Lien cliquable d'authentification en mode debug

![image](https://github.com/user-attachments/assets/cc8d16ad-941c-4578-84d2-eb1eb159a3f3)

