### PR TITLE
feat(home): afficher les questions en attente de réponse sur la page d'accueil

### DIFF
--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -22,6 +22,14 @@ class TopicQuerySet(models.QuerySet):
             .exclude(status=Topic.TOPIC_LOCKED)
             .exclude(type=Topic.TOPIC_ANNOUNCE)
             .filter(posts_count=1)
+            .select_related(
+                "forum",
+                "poster",
+                "poster__forum_profile",
+                "first_post",
+                "first_post__poster",
+            )
+            .order_by("-last_post_on")
         )
 
     def optimized_for_topics_list(self, user_id):

--- a/lacommunaute/pages/views.py
+++ b/lacommunaute/pages/views.py
@@ -8,6 +8,8 @@ from django.views.generic.base import TemplateView
 
 from lacommunaute.event.models import Event
 from lacommunaute.forum.models import Forum
+from lacommunaute.forum_conversation.forms import PostForm
+from lacommunaute.forum_conversation.models import Topic
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +30,8 @@ class HomeView(TemplateView):
         context["forums_category"] = Forum.objects.filter(parent__type=1).order_by("-updated")[:4]
         context["forum"] = Forum.objects.get_main_forum()
         context["upcoming_events"] = Event.objects.filter(date__gte=timezone.now()).order_by("date")[:4]
+        context["unanswered_topics"] = Topic.objects.unanswered()[:4]
+        context["form"] = PostForm(user=self.request.user)
         return context
 
 

--- a/lacommunaute/partner/tests/tests_partner_listview.py
+++ b/lacommunaute/partner/tests/tests_partner_listview.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from factory import Iterator
 
 from lacommunaute.partner.factories import PartnerFactory
 from lacommunaute.users.factories import UserFactory
@@ -21,7 +22,8 @@ def test_listview(client, db, snapshot, url):
 
 
 def test_pagination(client, db, snapshot, url):
-    PartnerFactory.create_batch(8 * 3 + 1)
+    num_of_partners = 8 * 3 + 1
+    PartnerFactory.create_batch(num_of_partners, name=Iterator([f"Partner {i}" for i in range(num_of_partners)]))
     response = client.get(url)
     assert response.status_code == 200
     assert str(parse_response_to_soup(response, selector="ul.pagination")) == snapshot(name="partner_pagination")

--- a/lacommunaute/templates/forum_conversation/topic_simple_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_simple_list.html
@@ -1,0 +1,62 @@
+{% load i18n %}
+<div id="topicsarea">
+    {% if topics or not hide_if_empty %}
+        <hr>
+        {% for topic in topics %}
+            <div class="row">
+                <div class="col-12">
+                    <div id="{{ topic.pk }}" class="post mb-3">
+                        <div class="mb-1 d-flex flex-column flex-md-row align-items-md-center">
+                            <p class="h4 mb-0 flex-grow-1">
+                                <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                   class="matomo-event"
+                                   data-matomo-category="engagement"
+                                   data-matomo-action="view"
+                                   data-matomo-option="topic">{{ topic.subject }}</a>
+                            </p>
+                        </div>
+                        <div class="pt-0">
+                            <div class="row">
+                                <div class="col-12 post-content-wrapper mb-1">
+                                    {% include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True forum=forum %}
+                                </div>
+                                <div class="col-12 post-content">
+                                    <div id="showmoretopicsarea{{ topic.pk }}">
+                                        {% include 'partials/rendered_md.html' with content=topic.first_post.content truncatechars=1 only %}
+                                        {% if topic.first_post.content.rendered|length > 200 %}
+                                            <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                               id="showmoretopic-button{{ topic.pk }}"
+                                               hx-target="#showmoretopicsarea{{ topic.pk }}"
+                                               hx-swap="outerHTML"
+                                               class="btn btn-link p-0 mh-auto matomo-event"
+                                               data-matomo-category="engagement"
+                                               data-matomo-action="showmore"
+                                               data-matomo-option="topic">{% trans "+ show more" %}</a>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="showmorepostsarea{{ topic.pk }}">
+                        <div id="postinfeedarea{{ topic.pk }}">
+                            {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row align-items-sm-center mb-3">
+                <div class="col-12 col-sm">
+                    {% include "forum_conversation/partials/topic_detail_actions.html" with posts_count=topic.posts_count %}
+                </div>
+            </div>
+            <hr>
+        {% endfor %}
+    {% endif %}
+</div>
+<script nonce="{{ request.csp_nonce }}">
+    var showmorepostsButtons = document.querySelectorAll('.showmoreposts-button')
+    showmorepostsButtons.forEach((button) => button.addEventListener('click', function() {
+        button.classList.add('d-none');
+    }));
+</script>

--- a/lacommunaute/templates/forum_conversation/topic_simple_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_simple_list.html
@@ -1,40 +1,31 @@
 {% load i18n %}
 <div id="topicsarea">
     {% if topics or not hide_if_empty %}
-        <hr>
-        {% for topic in topics %}
-            <div class="row">
-                <div class="col-12">
-                    <div id="{{ topic.pk }}" class="post mb-3">
-                        <div class="mb-1 d-flex flex-column flex-md-row align-items-md-center">
-                            <p class="h4 mb-0 flex-grow-1">
-                                <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                   class="matomo-event"
-                                   data-matomo-category="engagement"
-                                   data-matomo-action="view"
-                                   data-matomo-option="topic">{{ topic.subject }}</a>
-                            </p>
+        <ul class="list-group list-group-flush">
+            {% for topic in topics %}
+                <li class="list-group-item list-group-item-action">
+                    <div id="{{ topic.pk }}" class="post">
+                        <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                           class="h4 text-tertiary d-block mb-1 matom-event"
+                           data-matomo-category="engagement"
+                           data-matomo-action="view"
+                           data-matomo-option="topic">{{ topic.subject }}</a>
+                        <div class="mb-3">
+                            {% include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True forum=forum %}
                         </div>
-                        <div class="pt-0">
-                            <div class="row">
-                                <div class="col-12 post-content-wrapper mb-1">
-                                    {% include "forum_conversation/partials/poster.html" with post=topic.first_post topic=topic is_topic_head=True forum=forum %}
-                                </div>
-                                <div class="col-12 post-content">
-                                    <div id="showmoretopicsarea{{ topic.pk }}">
-                                        {% include 'partials/rendered_md.html' with content=topic.first_post.content truncatechars=1 only %}
-                                        {% if topic.first_post.content.rendered|length > 200 %}
-                                            <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                                               id="showmoretopic-button{{ topic.pk }}"
-                                               hx-target="#showmoretopicsarea{{ topic.pk }}"
-                                               hx-swap="outerHTML"
-                                               class="btn btn-link p-0 mh-auto matomo-event"
-                                               data-matomo-category="engagement"
-                                               data-matomo-action="showmore"
-                                               data-matomo-option="topic">{% trans "+ show more" %}</a>
-                                        {% endif %}
-                                    </div>
-                                </div>
+                        <div class="post-content">
+                            <div id="showmoretopicsarea{{ topic.pk }}">
+                                {% include 'partials/rendered_md.html' with content=topic.first_post.content truncatechars=1 only %}
+                                {% if topic.first_post.content.rendered|length > 200 %}
+                                    <a hx-get="{% url 'forum_conversation_extension:showmore_topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
+                                       id="showmoretopic-button{{ topic.pk }}"
+                                       hx-target="#showmoretopicsarea{{ topic.pk }}"
+                                       hx-swap="outerHTML"
+                                       class="btn btn-link p-0 mb-3 mt-n3 matomo-event"
+                                       data-matomo-category="engagement"
+                                       data-matomo-action="showmore"
+                                       data-matomo-option="topic">{% trans "+ show more" %}</a>
+                                {% endif %}
                             </div>
                         </div>
                     </div>
@@ -43,15 +34,12 @@
                             {% include "forum_conversation/partials/post_feed_form_collapsable.html" with post_form=form %}
                         </div>
                     </div>
-                </div>
-            </div>
-            <div class="row align-items-sm-center mb-3">
-                <div class="col-12 col-sm">
-                    {% include "forum_conversation/partials/topic_detail_actions.html" with posts_count=topic.posts_count %}
-                </div>
-            </div>
-            <hr>
-        {% endfor %}
+                    <div class="mb-3">
+                        {% include "forum_conversation/partials/topic_detail_actions.html" with posts_count=topic.posts_count %}
+                    </div>
+                </li>
+            {% endfor %}
+        </ul>
     {% endif %}
 </div>
 <script nonce="{{ request.csp_nonce }}">

--- a/lacommunaute/templates/forum_conversation/topic_simple_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_simple_list.html
@@ -6,7 +6,7 @@
                 <li class="list-group-item list-group-item-action">
                     <div id="{{ topic.pk }}" class="post">
                         <a href="{% url 'forum_conversation:topic' topic.forum.slug topic.forum.pk topic.slug topic.pk %}"
-                           class="h4 text-tertiary d-block mb-1 matom-event"
+                           class="h4 text-tertiary d-block mb-1 matomo-event"
                            data-matomo-category="engagement"
                            data-matomo-action="view"
                            data-matomo-option="topic">{{ topic.subject }}</a>

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -161,7 +161,7 @@
         </div>
     </section>
     {% if unanswered_topics %}
-        <section class="s-section mt-0" id="unanswered_topics">
+        <section class="s-section my-5 my-md-9" id="unanswered_topics">
             <div class="s-section__container container">
                 <div class="s-section__row row">
                     <div class="s-section__col col-12">

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -160,6 +160,20 @@
             </div>
         </div>
     </section>
+    {% if unanswered_topics %}
+        <section class="s-section mt-0" id="unanswered_topics">
+            <div class="s-section__container container">
+                <div class="s-section__row row">
+                    <div class="s-section__col col-12">
+                        <p class="h1 text-tertiary">Des professionnels ont besoin de votre aide !</p>
+                        {% with topics=unanswered_topics %}
+                            {% include "forum_conversation/topic_simple_list.html" with active_tag=active_tag %}
+                        {% endwith %}
+                    </div>
+                </div>
+            </div>
+        </section>
+    {% endif %}
     <section class="s-section my-5 my-md-10">
         <div class="s-section__container container container-max-lg">
             <div class="s-section__row row">


### PR DESCRIPTION
## Description

🎸 Valoriser les questions en attente de réponse dès la page d'acceuil, et permettre d'y répondre directement
🎸 Allègement de l'affichage, les questions en attente ne peuvent pas avoir de réponse certifiée. Les `attachments` et les sondages sont volontairement non affichés.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🎨 changement d'UI

### Points d'attention

🦺 ajout de la méthode `unanswered` dans `TopicQueryset`
🦺 duplication et simplification du  gabarit `topic_list` en `topic_simple_list`
🦺 enrichissement du contexte de `HomeView`
🦺 pas de pagination, seules les 4 plus récentes questions sont affichées. La section est cachée si aucune question n'est en attente


### Captures d'écran (optionnel)

page d'accueil avec questions en attente

![image](https://github.com/user-attachments/assets/9363a5a7-6a80-46ff-a6fc-e54920da937b)

page d'accueil sans question en attente

![image](https://github.com/user-attachments/assets/1f1d4258-0a13-47f4-ba5c-02061066c8ad)

