### PR TITLE
feat(notification): informer les abonnés dun forum des nouvelles questions

### DIFF
--- a/lacommunaute/notification/tests/tests_utils.py
+++ b/lacommunaute/notification/tests/tests_utils.py
@@ -51,6 +51,18 @@ class CollectNewUsersForOnBoardingTestCase(TestCase):
 
 
 class TestGetSerializedMessages:
+    def test_post_is_topic_head(self, db):
+        topic = TopicFactory(with_post=True)
+        notifications = [NotificationFactory(post=topic.first_post)]
+        assert get_serialized_messages(notifications) == [
+            {
+                "poster": topic.first_post.poster_display_name,
+                "action": "a posé une nouvelle question",
+                "forum": topic.forum.name,
+                "url": topic.get_absolute_url(with_fqdn=True),
+            }
+        ]
+
     def test_post_is_not_topic_head(self, db):
         post = PostFactory(topic=TopicFactory(with_post=True))
         notifications = [NotificationFactory(post=post)]

--- a/lacommunaute/notification/utils.py
+++ b/lacommunaute/notification/utils.py
@@ -21,7 +21,7 @@ def get_serialized_messages(notifications):
     return [
         {
             "poster": n.post.poster_display_name,
-            "action": f"a répondu à '{n.post.subject}'",
+            "action": "a posé une nouvelle question" if n.post.is_topic_head else f"a répondu à '{n.post.subject}'",
             "forum": n.post.topic.forum.name,
             "url": n.post.topic.get_absolute_url(with_fqdn=True),
         }


### PR DESCRIPTION
## Description

🎸 Informer les utilisateurs abonnés à un forum lorsqu'une nouvelle question est posée
🎸 La notification est incluse dans le `digest` quotidien

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 refactor des tests impactés en pytest


🦺 Lien avec d'autres PR
🦺 Code sensible


### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.
