### PR TITLE
refactor: améliorations mineures appel à l'API Brevo

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -362,7 +362,7 @@ SIB_SMTP_URL = os.path.join(SIB_URL, "smtp/email")
 SIB_CONTACTS_URL = os.path.join(SIB_URL, "contacts/import")
 
 SIB_API_KEY = os.getenv("SIB_API_KEY", "set-sib-api-key")
-DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.beta.gouv.fr")
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.gouv.fr")
 
 SIB_MAGIC_LINK_TEMPLATE = 31
 SIB_UNANSWERED_QUESTION_TEMPLATE = 10

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -30,7 +30,6 @@ def send_messages_notifications(delay: NotificationDelay):
         message_count_text = f"{message_count} message{pluralize(message_count, 's')}"
 
         params = {
-            "email_object": "Bonne nouvelle, ça bouge pour vous dans la communauté !",
             "email_thumbnail": (f"Vous avez {message_count_text} à découvrir sur la communauté de l'inclusion"),
             "messages": get_serialized_messages(recipient_notifications[:NEW_MESSAGES_EMAIL_MAX_PREVIEW]),
         }

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -55,7 +55,6 @@ class SendMessageNotificationsTestCase(TestCase):
         message_count_text = f"{message_count} message{pluralize(message_count, 's')}"
 
         params = {
-            "email_object": "Bonne nouvelle, ça bouge pour vous dans la communauté !",
             "email_thumbnail": (f"Vous avez {message_count_text} à découvrir sur la communauté de l'inclusion"),
             "messages": get_serialized_messages(recipient_notifications[:NEW_MESSAGES_EMAIL_MAX_PREVIEW]),
         }

--- a/lacommunaute/users/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/users/tests/__snapshots__/tests_views.ambr
@@ -528,8 +528,8 @@
   '''
 # ---
 # name: TestSendMagicLink.test_send_magic_link[DEV-1][send_magic_link_payload]
-  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.beta.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
+  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
 # ---
 # name: TestSendMagicLink.test_send_magic_link[PROD-0][send_magic_link_payload]
-  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.beta.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
+  '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
 # ---


### PR DESCRIPTION
## Description

🎸 mise à jour de `DEFAULT_FROM_EMAIL` en `noreply@inclusion.gouv.fr`
🎸 suppression d'un param statique dans l'appel au gabarit `SIB_NEW_MESSAGE_TEMPLATE`

## Type de changement

🚧 technique

