### PR TITLE
feat: renommage des upvotes

### DIFF
--- a/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
@@ -514,7 +514,7 @@
           
               <form hx-post="/upvote/forum/" hx-swap="outerHTML" hx-target="#upvotesarea10000" id="upvote-button10000">
                   <input name="pk" type="hidden" value="10000"/>
-                  <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="Sauvegarder" type="submit">
+                  <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="S'abonner" type="submit">
                       <i aria-hidden="true" class="ri-notification-2-fill me-1"></i><span>1</span>
                   </button>
               </form>
@@ -556,7 +556,7 @@
           
               <form hx-post="/upvote/forum/" hx-swap="outerHTML" hx-target="#upvotesarea10000" id="upvote-button10000">
                   <input name="pk" type="hidden" value="10000"/>
-                  <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="Sauvegarder" type="submit">
+                  <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="S'abonner" type="submit">
                       <i aria-hidden="true" class="ri-notification-2-fill me-1"></i><span>2</span>
                   </button>
               </form>
@@ -598,7 +598,7 @@
           
               <form hx-post="/upvote/forum/" hx-swap="outerHTML" hx-target="#upvotesarea10000" id="upvote-button10000">
                   <input name="pk" type="hidden" value="10000"/>
-                  <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="Sauvegarder" type="submit">
+                  <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="S'abonner" type="submit">
                       <i aria-hidden="true" class="ri-notification-2-fill me-1"></i><span>3</span>
                   </button>
               </form>

--- a/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum/tests/__snapshots__/tests_views.ambr
@@ -328,7 +328,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-10000%2F%2310000" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>0</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>0</span>
               </a>
           
       
@@ -487,7 +487,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-forum-[PK of Forum]%2F%23[PK of Forum]" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>0</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>0</span>
               </a>
           
       
@@ -500,7 +500,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-forum-[PK of Forum]%2F%23[PK of Forum]" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>0</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>0</span>
               </a>
           
       
@@ -515,7 +515,7 @@
               <form hx-post="/upvote/forum/" hx-swap="outerHTML" hx-target="#upvotesarea10000" id="upvote-button10000">
                   <input name="pk" type="hidden" value="10000"/>
                   <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="Sauvegarder" type="submit">
-                      <i aria-hidden="true" class="ri-bookmark-fill me-1"></i><span>1</span>
+                      <i aria-hidden="true" class="ri-notification-2-fill me-1"></i><span>1</span>
                   </button>
               </form>
           
@@ -529,7 +529,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-forum-[PK of Forum]%2F%23[PK of Forum]" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>1</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>1</span>
               </a>
           
       
@@ -542,7 +542,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-forum-[PK of Forum]%2F%23[PK of Forum]" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>1</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>1</span>
               </a>
           
       
@@ -557,7 +557,7 @@
               <form hx-post="/upvote/forum/" hx-swap="outerHTML" hx-target="#upvotesarea10000" id="upvote-button10000">
                   <input name="pk" type="hidden" value="10000"/>
                   <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="Sauvegarder" type="submit">
-                      <i aria-hidden="true" class="ri-bookmark-fill me-1"></i><span>2</span>
+                      <i aria-hidden="true" class="ri-notification-2-fill me-1"></i><span>2</span>
                   </button>
               </form>
           
@@ -571,7 +571,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-forum-[PK of Forum]%2F%23[PK of Forum]" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>2</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>2</span>
               </a>
           
       
@@ -584,7 +584,7 @@
       
           
               <a class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-placement="top" data-bs-toggle="tooltip" href="/users/login/?next=%2Fforum%2Ftest-forum-forum-[PK of Forum]%2F%23[PK of Forum]" title="Connectez-vous pour sauvegarder">
-                  <i aria-hidden="true" class="ri-bookmark-line me-1"></i><span>2</span>
+                  <i aria-hidden="true" class="ri-notification-2-line me-1"></i><span>2</span>
               </a>
           
       
@@ -599,7 +599,7 @@
               <form hx-post="/upvote/forum/" hx-swap="outerHTML" hx-target="#upvotesarea10000" id="upvote-button10000">
                   <input name="pk" type="hidden" value="10000"/>
                   <button class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-action="upvote" data-matomo-category="engagement" data-matomo-option="post" title="Sauvegarder" type="submit">
-                      <i aria-hidden="true" class="ri-bookmark-fill me-1"></i><span>3</span>
+                      <i aria-hidden="true" class="ri-notification-2-fill me-1"></i><span>3</span>
                   </button>
               </form>
           

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -663,7 +663,7 @@ class TopicViewTest(TestCase):
 
         response = self.client.get(self.url)
         self.assertContains(
-            response, '<i class="ri-bookmark-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200
+            response, '<i class="ri-notification-2-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200
         )
 
     def test_post_has_upvote_by_user(self):
@@ -673,7 +673,7 @@ class TopicViewTest(TestCase):
 
         response = self.client.get(self.url)
         self.assertContains(
-            response, '<i class="ri-bookmark-fill me-1" aria-hidden="true"></i><span>1</span>', status_code=200
+            response, '<i class="ri-notification-2-fill me-1" aria-hidden="true"></i><span>1</span>', status_code=200
         )
 
     def test_certified_post_is_highlighted(self):

--- a/lacommunaute/forum_conversation/tests/tests_views_htmx.py
+++ b/lacommunaute/forum_conversation/tests/tests_views_htmx.py
@@ -189,7 +189,7 @@ class PostListViewTest(TestCase):
 
         response = view.get(request)
         self.assertContains(
-            response, '<i class="ri-bookmark-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200
+            response, '<i class="ri-notification-2-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200
         )
 
         UpVoteFactory(content_object=post, voter=UserFactory())
@@ -197,7 +197,7 @@ class PostListViewTest(TestCase):
 
         response = view.get(request)
         self.assertContains(
-            response, '<i class="ri-bookmark-fill me-1" aria-hidden="true"></i><span>2</span>', status_code=200
+            response, '<i class="ri-notification-2-fill me-1" aria-hidden="true"></i><span>2</span>', status_code=200
         )
 
     def test_certified_post_highlight(self):
@@ -287,7 +287,7 @@ class PostFeedCreateViewTest(TestCase):
         self.assertContains(response, self.content, status_code=200)
         self.assertIsInstance(response.context["form"], PostForm)
         self.assertEqual(1, ForumReadTrack.objects.count())
-        self.assertContains(response, '<i class="ri-bookmark-line me-1" aria-hidden="true"></i><span>0</span>')
+        self.assertContains(response, '<i class="ri-notification-2-line me-1" aria-hidden="true"></i><span>0</span>')
         self.topic.refresh_from_db()
         self.assertEqual(self.topic.posts.count(), 2)
         self.assertEqual(

--- a/lacommunaute/forum_upvote/tests/test_forumupvoteview.py
+++ b/lacommunaute/forum_upvote/tests/test_forumupvoteview.py
@@ -32,12 +32,16 @@ def test_upvote_downvote_with_permission(client, db):
 
     # upvote
     response = client.post(url, data=form_data)
-    assertContains(response, '<i class="ri-bookmark-fill me-1" aria-hidden="true"></i><span>1</span>', status_code=200)
+    assertContains(
+        response, '<i class="ri-notification-2-fill me-1" aria-hidden="true"></i><span>1</span>', status_code=200
+    )
     assert UpVote.objects.get()
 
     # downvote
     response = client.post(url, data=form_data)
-    assertContains(response, '<i class="ri-bookmark-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200)
+    assertContains(
+        response, '<i class="ri-notification-2-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200
+    )
     assert not UpVote.objects.all()
 
 

--- a/lacommunaute/forum_upvote/tests/test_postupvoteview.py
+++ b/lacommunaute/forum_upvote/tests/test_postupvoteview.py
@@ -34,7 +34,9 @@ def test_upvote_with_permission(client, db):
 
     # upvote
     response = client.post(url, data=form_data)
-    assertContains(response, '<i class="ri-bookmark-fill me-1" aria-hidden="true"></i><span>1</span>', status_code=200)
+    assertContains(
+        response, '<i class="ri-notification-2-fill me-1" aria-hidden="true"></i><span>1</span>', status_code=200
+    )
     assert UpVote.objects.get(
         voter_id=user.id,
         object_id=topic.first_post.id,
@@ -43,7 +45,9 @@ def test_upvote_with_permission(client, db):
 
     # downvote
     response = client.post(url, data=form_data)
-    assertContains(response, '<i class="ri-bookmark-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200)
+    assertContains(
+        response, '<i class="ri-notification-2-line me-1" aria-hidden="true"></i><span>0</span>', status_code=200
+    )
     assert not UpVote.objects.all()
 
 

--- a/lacommunaute/templates/partials/header.html
+++ b/lacommunaute/templates/partials/header.html
@@ -69,16 +69,13 @@
                                                 <div class="dropdown-divider"></div>
                                             </li>
                                             <li>
-                                                <a href="{% url 'members:profile' user.username %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="member">Accéder à mon profil</a>
+                                                <a href="{% url 'members:profile' user.username %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="member">{% trans "Go to my profile" %}</a>
                                             </li>
                                             <li>
-                                                <a href="{% url 'forum_upvote:mine' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="upvotes">Accéder à mes sauvegardes</a>
+                                                <a href="{% url 'forum_upvote:mine' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="upvotes">{% trans "Go to my UpVotes" %}</a>
                                             </li>
                                             <li>
-                                                <a href="{% url 'event:myevents' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="event">Accéder à mes évènements</a>
-                                            </li>
-                                            <li>
-                                                <a href="{% url 'forum_extension:index' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forums">Accéder à mes thématiques</a>
+                                                <a href="{% url 'event:myevents' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="event">{% trans "Go to my events" %}</a>
                                             </li>
                                             {% if user.is_superuser %}
                                                 <li>
@@ -239,16 +236,13 @@
                                     <div class="dropdown-divider"></div>
                                 </li>
                                 <li>
-                                    <a href="{% url 'members:profile' user.username %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="member">Accéder à mon profil</a>
+                                    <a href="{% url 'members:profile' user.username %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="member">{% trans "Go to my profile" %}</a>
                                 </li>
                                 <li>
-                                    <a href="{% url 'forum_upvote:mine' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="upvotes">Accéder à mes sauvegardes</a>
+                                    <a href="{% url 'forum_upvote:mine' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="upvotes">{% trans "Go to my UpVotes" %}</a>
                                 </li>
                                 <li>
-                                    <a href="{% url 'event:myevents' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="event">Accéder à mes évènements</a>
-                                </li>
-                                <li>
-                                    <a href="{% url 'forum_extension:index' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="forums">Accéder à mes thématiques</a>
+                                    <a href="{% url 'event:myevents' %}" class="dropdown-item text-primary matomo-event" data-matomo-category="engagement" data-matomo-action="view" data-matomo-option="event">{% trans "Go to my events" %}</a>
                                 </li>
                                 {% if user.is_superuser %}
                                     <li>

--- a/lacommunaute/templates/partials/upvotes.html
+++ b/lacommunaute/templates/partials/upvotes.html
@@ -9,12 +9,12 @@
                   hx-swap="outerHTML">
                 <input type='hidden' name='pk' value="{{ obj.pk }}" />
                 <button type="submit" title="{% trans "UpVotes" %}" class="btn btn-sm btn-ico btn-secondary matomo-event px-2" data-matomo-category="engagement" data-matomo-action="upvote" data-matomo-option="post">
-                    <i class="{% if obj.has_upvoted %}ri-bookmark-fill{% else %}ri-bookmark-line{% endif %} me-1" aria-hidden="true"></i><span>{{ counter }}</span>
+                    <i class="{% if obj.has_upvoted %}ri-notification-2-fill{% else %}ri-notification-2-line{% endif %} me-1" aria-hidden="true"></i><span>{{ counter }}</span>
                 </button>
             </form>
         {% else %}
             <a href="{% login_url next_url obj.id %}" class="btn btn-sm btn-ico btn-link btn-secondary px-2" data-bs-toggle="tooltip" data-bs-placement="top" title="Connectez-vous pour sauvegarder">
-                <i class="{% if obj.has_upvoted %}ri-bookmark-fill{% else %}ri-bookmark-line{% endif %} me-1" aria-hidden="true"></i><span>{{ counter }}</span>
+                <i class="{% if obj.has_upvoted %}ri-notification-2-fill{% else %}ri-notification-2-line{% endif %} me-1" aria-hidden="true"></i><span>{{ counter }}</span>
             </a>
         {% endif %}
     {% endwith %}

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -914,10 +914,13 @@ msgid "Topics Engagement"
 msgstr "Engagement par sujet"
 
 msgid "UpVotes"
-msgstr "Sauvegarder"
+msgstr "S'abonner"
 
 msgid "My UpVotes"
-msgstr "Mes sauvegardes"
+msgstr "Mes abonnements"
+
+msgid "Go to my UpVotes"
+msgstr "Voir mes abonnements"
 
 msgid "Likes"
 msgstr "Ce sujet m'intéresse"
@@ -1036,3 +1039,9 @@ msgstr "Partenaire"
 
 msgid "Partners"
 msgstr "Nos partenaires"
+
+msgid "Go to my profile"
+msgstr "Voir mon profil"
+
+msgid "Go to my events"
+msgstr "Voir mes évènements"


### PR DESCRIPTION
## Description

🎸 Renommer les `UpVotes`, de `sauvegardes` en `abonnements`. 

## Type de changement

🎨 changement d'UI

### Captures d'écran (optionnel)

`/upvotes/`

![image](https://github.com/user-attachments/assets/661b0988-846e-46e3-b52d-73738cdb44b1)

`Forum`

![image](https://github.com/user-attachments/assets/b0b01f21-13b1-46ee-9459-fb7dad143a00)
![image](https://github.com/user-attachments/assets/c7378745-e1a7-487a-8707-8670ad612276)


`Post`

![image](https://github.com/user-attachments/assets/120ce270-8c67-45da-875a-ee5ea1fb7769)
![image](https://github.com/user-attachments/assets/0a59fc42-84a8-49f3-b3a3-752ce447d75e)

`user menu`

![image](https://github.com/user-attachments/assets/cba79d2b-98cb-4b5b-a79f-00559c7e09b0)

