### PR TITLE
fix: hydratation du parametre `next` dans l'url proconnect:authorize

### DIFF
--- a/lacommunaute/templates/registration/login_with_magic_link.html
+++ b/lacommunaute/templates/registration/login_with_magic_link.html
@@ -25,7 +25,7 @@
                             <p>
                                 ProConnect vous permet d'accéder à de nombreux services en ligne en utilisant l'un de vos comptes professionnels existants.
                             </p>
-                            <a href="{% url 'openid_connect:authorize' %}?next={{ next }}" rel="nofollow" class="proconnect-button"></a>
+                            <a href="{% url 'openid_connect:authorize' %}?next={{ request.GET.next }}" rel="nofollow" class="proconnect-button"></a>
                             <p>
                                 <a href="https://proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
                                     Qu’est-ce que ProConnect ?

--- a/lacommunaute/users/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/users/tests/__snapshots__/tests_views.ambr
@@ -230,7 +230,7 @@
                               <p>
                                   ProConnect vous permet d'accéder à de nombreux services en ligne en utilisant l'un de vos comptes professionnels existants.
                               </p>
-                              <a class="proconnect-button" href="/pro_connect/authorize?next=" rel="nofollow"></a>
+                              <a class="proconnect-button" href="/pro_connect/authorize?next=/" rel="nofollow"></a>
                               <p>
                                   <a href="https://proconnect.gouv.fr/" rel="noopener noreferrer" target="_blank" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
                                       Qu’est-ce que ProConnect ?
@@ -307,7 +307,7 @@
                               <p>
                                   ProConnect vous permet d'accéder à de nombreux services en ligne en utilisant l'un de vos comptes professionnels existants.
                               </p>
-                              <a class="proconnect-button" href="/pro_connect/authorize?next=" rel="nofollow"></a>
+                              <a class="proconnect-button" href="/pro_connect/authorize?next=/topics/" rel="nofollow"></a>
                               <p>
                                   <a href="https://proconnect.gouv.fr/" rel="noopener noreferrer" target="_blank" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
                                       Qu’est-ce que ProConnect ?
@@ -418,6 +418,83 @@
                                       <div class="form-row align-items-center justify-content-end gx-3">
                                           <div class="form-group col col-lg-auto order-2 order-lg-3">
                                               <input name="next" type="hidden" value=""/>
+                                              <input class="btn btn-block btn-primary" type="submit" value="Recevoir le lien de connexion"/>
+                                          </div>
+                                      </div>
+                                  </div>
+                              </div>
+                          </form>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: TestLoginView.test_content[http://www.unallowed_host.com][login_view_content]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-lg-8 col-12">
+                      <h1 class="s-title-01__title h1">Se connecter | S'inscrire</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="s-section__col col-12 col-lg-7">
+                      <div class="c-form">
+                          <div class="text-center">
+                              <p>
+                                  ProConnect vous permet d'accéder à de nombreux services en ligne en utilisant l'un de vos comptes professionnels existants.
+                              </p>
+                              <a class="proconnect-button" href="/pro_connect/authorize?next=http://www.unallowed_host.com" rel="nofollow"></a>
+                              <p>
+                                  <a href="https://proconnect.gouv.fr/" rel="noopener noreferrer" target="_blank" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
+                                      Qu’est-ce que ProConnect ?
+                                  </a>
+                              </p>
+                          </div>
+                          <hr class="my-5" data-it-text="ou"/>
+                          <form action="." enctype="multipart/form-data" method="post" novalidate="">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              
+                              <fieldset>
+                                  <p class="h4">Se connecter avec votre email</p>
+                                  <p class="text-muted">✨ Nous allons vous envoyer un code magique pour vous connecter sans mot de passe.</p>
+                                  
+  
+  <div class="form-group" id="div_id_email">
+      
+          
+          
+              <input class="form-control" id="id_email" maxlength="320" name="email" placeholder="Votre adresse email" required="" type="email"/>
+          
+      
+      
+      
+      
+  </div>
+  
+                              </fieldset>
+                              <div class="row">
+                                  <div class="col-12">
+                                      <div class="form-row align-items-center justify-content-end gx-3">
+                                          <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                              <input name="next" type="hidden" value="http://www.unallowed_host.com"/>
                                               <input class="btn btn-block btn-primary" type="submit" value="Recevoir le lien de connexion"/>
                                           </div>
                                       </div>

--- a/lacommunaute/users/tests/tests_views.py
+++ b/lacommunaute/users/tests/tests_views.py
@@ -115,7 +115,7 @@ class TestSendMagicLink:
 
 
 class TestLoginView:
-    @pytest.mark.parametrize("next_url", [None, "/", "/topics/"])
+    @pytest.mark.parametrize("next_url", [None, "/", "/topics/", "http://www.unallowed_host.com"])
     def test_content(self, client, db, next_url, snapshot):
         url = reverse("users:login") + f"?next={next_url}" if next_url else reverse("users:login")
         response = client.get(url)


### PR DESCRIPTION
## Description

🎸 param non valorizé à tort

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Points d'attention

🦺 extension des tests
