### PR TITLE
feat: POC, autoconnection les emplois vers la commu via Pro Connect

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -102,6 +102,7 @@ DJANGO_MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "lacommunaute.utils.middleware.ParkingPageMiddleware",
+    "lacommunaute.openid_connect.middleware.ProConnectLoginMiddleware",
 ]
 
 THIRD_PARTIES_MIDDLEWARE = [

--- a/lacommunaute/openid_connect/middleware.py
+++ b/lacommunaute/openid_connect/middleware.py
@@ -6,11 +6,10 @@ from django.utils.http import urlencode
 
 class ProConnectLoginMiddleware(MiddlewareMixin):
     def process_request(self, request):
-        query_params = request.GET.copy()
-
-        if "proconnect_login" not in query_params:
+        if "proconnect_login" not in request.GET:
             return
 
+        query_params = request.GET.copy()
         query_params.pop("proconnect_login")
         new_url = (
             f"{request.path}?{urlencode({k: v for k, v in query_params.items() if v})}"

--- a/lacommunaute/openid_connect/middleware.py
+++ b/lacommunaute/openid_connect/middleware.py
@@ -8,11 +8,17 @@ class ProConnectLoginMiddleware(MiddlewareMixin):
     def process_request(self, request):
         query_params = request.GET.copy()
 
-        if "proconnect_login" in query_params:
-            query_params.pop("proconnect_login")
-            new_url = f"{request.path}?{urlencode(query_params)}" if query_params else request.path
+        if "proconnect_login" not in query_params:
+            return
 
-            if not request.user.is_authenticated:
-                return HttpResponseRedirect(reverse("openid_connect:authorize") + f"?next={new_url}")
+        query_params.pop("proconnect_login")
+        new_url = (
+            f"{request.path}?{urlencode({k: v for k, v in query_params.items() if v})}"
+            if query_params
+            else request.path
+        )
 
-            return HttpResponseRedirect(new_url)
+        if not request.user.is_authenticated:
+            return HttpResponseRedirect(reverse("openid_connect:authorize") + f"?next={new_url}")
+
+        return HttpResponseRedirect(new_url)

--- a/lacommunaute/openid_connect/middleware.py
+++ b/lacommunaute/openid_connect/middleware.py
@@ -1,0 +1,18 @@
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.http import urlencode
+
+
+class ProConnectLoginMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        query_params = request.GET.copy()
+
+        if "proconnect_login" in query_params:
+            query_params.pop("proconnect_login")
+            new_url = f"{request.path}?{urlencode(query_params)}" if query_params else request.path
+
+            if not request.user.is_authenticated:
+                return HttpResponseRedirect(reverse("openid_connect:authorize") + f"?next={new_url}")
+
+            return HttpResponseRedirect(new_url)

--- a/lacommunaute/openid_connect/tests/test_middleware.py
+++ b/lacommunaute/openid_connect/tests/test_middleware.py
@@ -1,5 +1,6 @@
 import pytest
 from django.urls import reverse
+from pytest_django.asserts import assertRedirects, assertTemplateUsed
 
 from lacommunaute.users.factories import UserFactory
 
@@ -15,8 +16,7 @@ from lacommunaute.users.factories import UserFactory
 def test_redirect_for_authenticated_user(client, db, params, expected):
     client.force_login(UserFactory())
     response = client.get(f"/{params}")
-    assert response.url == f"/{expected}"
-    assert response.status_code == 302
+    assertRedirects(response, f"/{expected}")
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,7 @@ def test_redirect_for_authenticated_user(client, db, params, expected):
 )
 def test_redirect_for_anonymous_user(client, db, params, expected):
     response = client.get(f"/{params}")
-    assert response.url == f"{reverse('openid_connect:authorize')}?next={expected}"
-    assert response.status_code == 302
+    assertRedirects(response, f"{reverse('openid_connect:authorize')}?next={expected}", fetch_redirect_response=False)
 
 
 @pytest.mark.parametrize(
@@ -48,4 +47,4 @@ def test_wo_proconnect_login_param(client, db, logged, params):
     if logged:
         client.force_login(UserFactory())
     response = client.get(f"/{params}")
-    assert response.status_code == 200
+    assertTemplateUsed(response, "pages/home.html")

--- a/lacommunaute/openid_connect/tests/test_middleware.py
+++ b/lacommunaute/openid_connect/tests/test_middleware.py
@@ -1,0 +1,51 @@
+import pytest
+from django.urls import reverse
+
+from lacommunaute.users.factories import UserFactory
+
+
+@pytest.mark.parametrize(
+    "params,expected",
+    [
+        ("?proconnect_login=true", ""),
+        ("?proconnect_login=true&param=1", "?param=1"),
+        ("?param=1&proconnect_login=true", "?param=1"),
+    ],
+)
+def test_redirect_for_authenticated_user(client, db, params, expected):
+    client.force_login(UserFactory())
+    response = client.get(f"/{params}")
+    assert response.url == f"/{expected}"
+    assert response.status_code == 302
+
+
+@pytest.mark.parametrize(
+    "params,expected",
+    [
+        ("?proconnect_login=true", "/"),
+        ("?proconnect_login=true&param=1", "/?param=1"),
+        ("?param=1&proconnect_login=true", "/?param=1"),
+    ],
+)
+def test_redirect_for_anonymous_user(client, db, params, expected):
+    response = client.get(f"/{params}")
+    assert response.url == f"{reverse('openid_connect:authorize')}?next={expected}"
+    assert response.status_code == 302
+
+
+@pytest.mark.parametrize(
+    "params, logged",
+    [
+        ("", True),
+        ("?param=1", True),
+        ("?param=1&key=2", True),
+        ("", False),
+        ("?param=1", False),
+        ("?param=1&key=2", False),
+    ],
+)
+def test_wo_proconnect_login_param(client, db, logged, params):
+    if logged:
+        client.force_login(UserFactory())
+    response = client.get(f"/{params}")
+    assert response.status_code == 200


### PR DESCRIPTION
# AutoConnect les emplois <> la commu

Partie 1 : les emplois > la commu
Scope : Orienteurs et SIAE

## Description

🎸 Permettre à un utilisateur authentifié dans le site des emplois via ProConnect, d'être automatiquement connecté via ProConnect dans la communauté

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 capture du paramètre `proconnect_login` dans l'url par un `middleware` dédié
🦺 retraitement de l'url pour supprimer le paramètre `proconnect_login` dans tous les cas

