### PR TITLE
fix(stats): desactivation de la collecte des stats automatique

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,10 +1,6 @@
 [
     "*/10 * * * * $ROOT/clevercloud/rebuild_index.sh",
     "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
-    "0 7 * * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats",
-    "5 7 * * * $ROOT/clevercloud/run_management_command.sh collect_django_stats",
-    "10 7 1 * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats --period month",
-    "15 7 * * 1 $ROOT/clevercloud/run_management_command.sh collect_matomo_forum_stats",
     "*/15 7-21 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications asap",
     "20 6 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications day",
     "10 6-22 * * * $ROOT/clevercloud/run_management_command.sh add_user_to_list_when_register",

--- a/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/stats/tests/__snapshots__/tests_views.ambr
@@ -16,6 +16,24 @@
   <main class="s-main" id="main" role="main">
               
                   
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
+                  
               
               
       <div class="container">
@@ -165,6 +183,24 @@
   '''
   <main class="s-main" id="main" role="main">
               
+                  
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
                   
               
               
@@ -316,6 +352,24 @@
   <main class="s-main" id="main" role="main">
               
                   
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
+                  
               
               
       <div class="container">
@@ -465,6 +519,24 @@
   '''
   <main class="s-main" id="main" role="main">
               
+                  
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
                   
               
               
@@ -616,6 +688,24 @@
   <main class="s-main" id="main" role="main">
               
                   
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
+                  
               
               
       <div class="container">
@@ -766,6 +856,24 @@
   <main class="s-main" id="main" role="main">
               
                   
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
+                  
               
               
       <div class="container">
@@ -915,6 +1023,24 @@
   '''
   <main class="s-main" id="main" role="main">
               
+                  
+                      <section class="s-section m-0">
+                          <div class="s-section__container container">
+                              <div class="s-section__row row">
+                                  <div class="s-section__col col-12"><div id="messages">
+      
+          
+              <div class="alert alert-warning alert-dismissible fade show mt-3" role="status">
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+                  La collecte des statistiques est desactivée pour le moment.
+              </div>
+          
+      
+  </div>
+  </div>
+                              </div>
+                          </div>
+                      </section>
                   
               
               

--- a/lacommunaute/stats/views.py
+++ b/lacommunaute/stats/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from dateutil.relativedelta import relativedelta
+from django.contrib import messages
 from django.db.models import Avg, CharField, Count, OuterRef, Subquery, Sum
 from django.db.models.functions import Cast
 from django.shortcuts import render
@@ -79,6 +80,8 @@ class StatistiquesPageView(TemplateView):
         context["dsp_count"] = self.get_dsp_count()
         context = {**context, **self.get_funnel_data()}
 
+        messages.warning(self.request, "La collecte des statistiques est desactivée pour le moment.")
+
         return context
 
 
@@ -99,6 +102,9 @@ class BaseDetailStatsView(TemplateView):
         context = super().get_context_data(**kwargs)
         context["stats"] = self.get_detailled_stats()
         context["box_title"] = self.box_title
+
+        messages.warning(self.request, "La collecte des statistiques est desactivée pour le moment.")
+
         return context
 
 
@@ -155,6 +161,8 @@ class DocumentStatsView(View):
             else "sum_time_spent"
         )
         objects = objects.order_by("-" + sort_key)
+
+        messages.warning(self.request, "La collecte des statistiques est desactivée pour le moment.")
 
         return render(
             request,


### PR DESCRIPTION
## Description

🐛 Le calcul des rapports de données matomo bagotte. Les données obtenues sont erronées et nécessitent une reprise manuelle au moins 2 fois/semaine.
⚠️ la collecte automatique est desactivée.

![image](https://github.com/user-attachments/assets/64af7c33-0b76-4805-a6a9-022f646bb391)


## Type de changement

🪲 Bug externe
🚧 technique