### PR TITLE
fix: 🦇 désactiver la suppression en masse des `Post` depuis l'admin django

### DIFF
--- a/lacommunaute/forum_conversation/admin.py
+++ b/lacommunaute/forum_conversation/admin.py
@@ -6,9 +6,9 @@ from lacommunaute.forum_conversation.models import CertifiedPost, Post, Topic
 
 class PostAdmin(BasePostAdmin):
     def get_actions(self, request):
-        # delete_selected action does not call delete method of the model
-        # related topic is not update (last_post, posts_count) making
-        # the website inconsistent
+        # delete_selected action does not call delete method of the model, so Related topic is not updated.
+        # When the last post of a topic is deleted, topic.posts_count remains to 1, saying ambiguous information.
+        # So we remove the delete_selected action to force the user to delete posts one by one.
         return []
 
     list_filter = BasePostAdmin.list_filter + ("approved",)

--- a/lacommunaute/forum_conversation/admin.py
+++ b/lacommunaute/forum_conversation/admin.py
@@ -11,6 +11,8 @@ class PostAdmin(BasePostAdmin):
         # the website inconsistent
         return []
 
+    list_filter = BasePostAdmin.list_filter + ("approved",)
+
 
 class PostInline(admin.StackedInline):
     model = Post
@@ -30,7 +32,7 @@ class TopicAdmin(BaseTopicAdmin):
     inlines = [
         PostInline,
     ]
-    list_filter = BaseTopicAdmin.list_filter + ("type",)
+    list_filter = BaseTopicAdmin.list_filter + ("type", "approved")
 
 
 class CertifiedPostAdmin(admin.ModelAdmin):

--- a/lacommunaute/forum_conversation/admin.py
+++ b/lacommunaute/forum_conversation/admin.py
@@ -1,7 +1,15 @@
 from django.contrib import admin
-from machina.apps.forum_conversation.admin import TopicAdmin as BaseTopicAdmin
+from machina.apps.forum_conversation.admin import PostAdmin as BasePostAdmin, TopicAdmin as BaseTopicAdmin
 
 from lacommunaute.forum_conversation.models import CertifiedPost, Post, Topic
+
+
+class PostAdmin(BasePostAdmin):
+    def get_actions(self, request):
+        # delete_selected action does not call delete method of the model
+        # related topic is not update (last_post, posts_count) making
+        # the website inconsistent
+        return []
 
 
 class PostInline(admin.StackedInline):
@@ -34,6 +42,8 @@ class CertifiedPostAdmin(admin.ModelAdmin):
     )
 
 
+admin.site.unregister(Post)
+admin.site.register(Post, PostAdmin)
 admin.site.unregister(Topic)
 admin.site.register(Topic, TopicAdmin)
 admin.site.register(CertifiedPost, CertifiedPostAdmin)

--- a/lacommunaute/forum_conversation/factories.py
+++ b/lacommunaute/forum_conversation/factories.py
@@ -58,6 +58,11 @@ class TopicFactory(BaseTopicFactory):
                 poster=factory.SelfAttribute("topic.poster"),
             )
         )
+        with_disapproved_post = factory.Trait(
+            post=factory.RelatedFactory(
+                PostFactory, factory_related_name="topic", poster=factory.SelfAttribute("topic.poster"), approved=False
+            )
+        )
 
     @factory.post_generation
     def with_poll_vote(self, create, extracted, **kwargs):

--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -16,12 +16,9 @@ from lacommunaute.users.models import User
 
 
 class TopicQuerySet(models.QuerySet):
-    def unanswered(self):
+    def _for_topics_list(self):
         return (
             self.exclude(approved=False)
-            .exclude(status=Topic.TOPIC_LOCKED)
-            .exclude(type=Topic.TOPIC_ANNOUNCE)
-            .filter(posts_count=1)
             .select_related(
                 "forum",
                 "poster",
@@ -32,16 +29,19 @@ class TopicQuerySet(models.QuerySet):
             .order_by("-last_post_on")
         )
 
+    def unanswered(self):
+        return (
+            self._for_topics_list()
+            .exclude(status=Topic.TOPIC_LOCKED)
+            .exclude(type=Topic.TOPIC_ANNOUNCE)
+            .filter(posts_count=1)
+        )
+
     def optimized_for_topics_list(self, user_id):
         return (
-            self.exclude(approved=False)
+            self._for_topics_list()
             .filter(type__in=[Topic.TOPIC_POST, Topic.TOPIC_STICKY, Topic.TOPIC_ANNOUNCE])
             .select_related(
-                "forum",
-                "poster",
-                "poster__forum_profile",
-                "first_post",
-                "first_post__poster",
                 "certified_post",
                 "certified_post__post",
                 "certified_post__post__poster",
@@ -54,7 +54,6 @@ class TopicQuerySet(models.QuerySet):
                 "certified_post__post__attachments",
                 "tags",
             )
-            .order_by("-last_post_on")
         )
 
 


### PR DESCRIPTION
## Description

🎸 Il est apparu un cas de `Topic` où `posts_count` était supérieur à zéro après la suppression du `Post` associé via l'admin.
🎸 Ce `Topic` a fait échouer en erreur 500, l'affichage des listes de `Topic`, lors de la tentative d'affichage des données de détail du `first_post`

🪭 Issue #860, https://inclusion.sentry.io/issues/14670791/?project=4508410606452816
🪭 Cas reproduit en supprimant des `Post` depuis la liste dans l'admin
🪭 Cause identifiée : la méthode `delete_selected` n'appelle pas la méthode `delete` de `machina` sur ces objets. Les données dénormalisées des `Topic` associés ne sont pas mises à jour.

🧦 Patch : desactivation de la méthode `delete_selected` dans l'admin

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique

### Points d'attention

🦺 factorisation des paramètres commun des queryset `unanswered` et `optimized_for_topics_list`
🦺 mise à jour des tests impactés et ajout du trait `with_disapproved_post`, réécriture simplifiée en pytest
🦺 des cas similaires peuvent se produire sur les `Topic` vs les données dénormalisées des `Forum`. Celles-ci ne sont pas exploitées dans l'UI, pas d'incidence pour le moment.
