### PR TITLE
chore: mise en cache en environnement de developpement

### DIFF
--- a/lacommunaute/conftest.py
+++ b/lacommunaute/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from django.core.management import call_command
+
+
+@pytest.fixture(scope="session", autouse=True)
+def run_compress(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        call_command("compress", "--force")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = config.settings.dev
+DJANGO_SETTINGS_MODULE = config.settings.base
 python_files = tests*.py test_*.py
 addopts =
     --reuse-db


### PR DESCRIPTION
## 🐗 problème rencontré 

### CI
🦺  `DatabaseCache` => tests ok

### pytest local :
🦺 `DatabaseCache` => tests KO 🧧 
```
FAILED lacommunaute/forum/tests/tests_views.py::ForumViewTest::test_filtered_queryset_on_tag - AssertionError: 32 != 20 : 32 queries executed, 20 expected
FAILED lacommunaute/forum/tests/tests_views.py::TestDocumentationCategoryForumContent::test_numqueries_on_tags - Failed: Expected to perform 19 queries but 31 were done (add -v option to show queries)
FAILED lacommunaute/forum_conversation/tests/tests_views.py::TopicViewTest::test_numqueries - AssertionError: 51 != 39 : 51 queries executed, 39 expected
FAILED lacommunaute/stats/tests/tests_views.py::TestForumStatView::test_num_queries - Failed: Expected to perform 7 queries but 19 were done (add -v option to show queries)
FAILED lacommunaute/forum/tests/tests_views.py::ForumViewTest::test_queries - AssertionError: 34 != 22 : 34 queries executed, 22 expected
FAILED lacommunaute/forum_upvote/tests/test_upvotelistview.py::test_numqueries - Failed: Expected to perform 37 queries but 49 were done (add -v option to show queries)
FAILED lacommunaute/pages/tests/test_homepage.py::test_numqueries - Failed: Expected to perform 10 queries but 22 were done (add -v option to show queries)
```
🦺 `DummyCache` ou `LocMemCache` => tests OK 🍏 

🦺 avec les settings de `config.settings.base` + `COMPRESS_OFFLINE=False` => tests KO 🧧 

## 🦄  solution

* forcer la compression avant l'execution des tests pour eviter les écritures en DB surnuméraires
* harmoniser les settings utilisés par pytest en local et dans la CI

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🚧 technique
