### PR TITLE
refactor: isoler les settings de test

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,42 +1,5 @@
-PYTHONPATH=.
-
-# for Django
-DJANGO_SETTINGS_MODULE=config.settings.dev
-POSTGRESQL_ADDON_HOST=localhost
-POSTGRESQL_ADDON_DB=communaute
-POSTGRESQL_ADDON_USER=communaute
-POSTGRESQL_ADDON_PASSWORD=password
-
-# GITHUB_ACCESS_TOKEN is used to update changelog from last release.
-GITHUB_ACCESS_TOKEN=__key_to_be_set__
-GITHUB_REPO=betagouv/itou-communaute-django
-
-# SENDINBLUE API KEY
-SIB_API_KEY=__key_to_be_set__
-
-# for Sentry
-#SENTRY_DSN=__url_to_be_set__
-
-# for Pro Connect
-OPENID_CONNECT_BASE_URL=http://127.0.0.1:8080
-OPENID_CONNECT_CLIENT_ID=local_openid_connect
-OPENID_CONNECT_CLIENT_SECRET=password
-
-# parking page
-PARKING_PAGE=True
-
-# Path to the itou-backup project repository.
-PATH_TO_BACKUPS=~/path/to/backups
-
-# bucket for test purpose only
-CELLAR_ADDON_KEY_ID=minioadmin
-CELLAR_ADDON_KEY_SECRET=minioadmin
-CELLAR_ADDON_HOST=localhost:9000
-CELLAR_ADDON_PROTOCOL=http
-
-# itou-backups
-export RCLONE_S3_ACCESS_KEY_ID=ACCESS_KEY_ID
-export RCLONE_S3_SECRET_ACCESS_KEY=SECRET_ACCESS_KEY
-export RCLONE_CRYPT_PASSWORD=CRYPT-PASSWORD
-export RCLONE_CRYPT_PASSWORD2=CRYPT-PASSWORD2
-export RCLONE_REMOTE_NAME=communaute
+# for psql
+PGDATABASE=communaute
+PGHOST=localhost
+PGUSER=communaute
+PGPASSWORD=password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,7 @@ jobs:
       PGPASSWORD: password
       PGHOST: localhost
       PGUSER: postgres
-      POSTGRESQL_ADDON_DB: communaute
-      POSTGRESQL_ADDON_USER: postgres
-      POSTGRESQL_ADDON_PASSWORD: password
+
     services:
       minio:
         image: bitnami/minio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHONPATH: .
-      DJANGO_SETTINGS_MODULE: config.settings.base
-      DJANGO_SECRET_KEY: ministryofsillywalks
+      DJANGO_SETTINGS_MODULE: config.settings.test
       CPUCOUNT: 1
       PGPASSWORD: password
       PGHOST: localhost
@@ -17,10 +16,6 @@ jobs:
       POSTGRESQL_ADDON_DB: communaute
       POSTGRESQL_ADDON_USER: postgres
       POSTGRESQL_ADDON_PASSWORD: password
-      CELLAR_ADDON_KEY_ID: minioadmin
-      CELLAR_ADDON_KEY_SECRET: minioadmin
-      CELLAR_ADDON_PROTOCOL: http
-      CELLAR_ADDON_HOST: localhost:9000
     services:
       minio:
         image: bitnami/minio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: 💂 Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
           cache-dependency-path: requirements/dev.txt
       - name: 📥 Install dependencies

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -18,7 +18,7 @@ env:
   CONFIGURATION_ADDON: ${{ secrets.CLEVER_REVIEW_APPS_CONFIGURATION_ADDON }}
   S3_ADDON: ${{ secrets.CLEVER_REVIEW_APPS_S3_ADDON }}
   BRANCH: ${{ github.head_ref }}
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   create:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -360,8 +360,8 @@ MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN", None)
 # SENDINBLUE
 # ---------------------------------------
 SIB_URL = os.getenv("SIB_URL", "http://test.com")
-SIB_SMTP_URL = os.path.join(SIB_URL, "smtp/email")
-SIB_CONTACTS_URL = os.path.join(SIB_URL, "contacts/import")
+SIB_SMTP_ROUTE = "smtp/email"
+SIB_CONTACTS_ROUTE = "contacts/import"
 
 SIB_API_KEY = os.getenv("SIB_API_KEY", "set-sib-api-key")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.gouv.fr")

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -268,14 +268,12 @@ COMMU_FQDN = os.getenv("COMMU_FQDN", "communaute.inclusion.beta.gouv.fr")
 # S3 uploads
 # ------------------------------------------------------------------------------
 
-AWS_S3_ACCESS_KEY_ID = os.getenv("CELLAR_ADDON_KEY_ID", "123")
-AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_KEY_SECRET", "secret")
-AWS_S3_ENDPOINT_URL = (
-    f"{os.getenv('CELLAR_ADDON_PROTOCOL', 'https')}://{os.getenv('CELLAR_ADDON_HOST', 'set-var-env.com')}"
-)
-AWS_STORAGE_BUCKET_NAME = os.getenv("S3_STORAGE_BUCKET_NAME", "private-bucket")
-AWS_STORAGE_BUCKET_NAME_PUBLIC = os.getenv("S3_STORAGE_BUCKET_NAME_PUBLIC", "public-bucket")
-AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_STORAGE_BUCKET_REGION", "eu-west-3")
+AWS_S3_ACCESS_KEY_ID = os.getenv("CELLAR_ADDON_KEY_ID")
+AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_KEY_SECRET")
+AWS_S3_ENDPOINT_URL = f"{os.getenv('CELLAR_ADDON_PROTOCOL')}://{os.getenv('CELLAR_ADDON_HOST')}"
+AWS_STORAGE_BUCKET_NAME = os.getenv("S3_STORAGE_BUCKET_NAME")
+AWS_STORAGE_BUCKET_NAME_PUBLIC = os.getenv("S3_STORAGE_BUCKET_NAME_PUBLIC")
+AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_STORAGE_BUCKET_REGION")
 
 # MEDIA CONFIGURATION
 # ------------------------------------------------------------------------------
@@ -359,11 +357,11 @@ MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN", None)
 
 # SENDINBLUE
 # ---------------------------------------
-SIB_URL = os.getenv("SIB_URL", "http://test.com")
+SIB_URL = os.getenv("SIB_URL")
 SIB_SMTP_ROUTE = "smtp/email"
 SIB_CONTACTS_ROUTE = "contacts/import"
 
-SIB_API_KEY = os.getenv("SIB_API_KEY", "set-sib-api-key")
+SIB_API_KEY = os.getenv("SIB_API_KEY")
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@inclusion.gouv.fr")
 
 SIB_MAGIC_LINK_TEMPLATE = 31

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -3,14 +3,11 @@ import socket
 
 from lacommunaute.utils.enums import Environment
 
-from .base import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F403 F401
+from .test import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F403 F401
 
 
 # Django settings
 # ---------------
-SECRET_KEY = "foobar"
-
-
 DEBUG = True
 ENVIRONMENT = Environment.DEV
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -11,6 +11,14 @@ SECRET_KEY = "v3ry_s3cr3t_k3y"
 
 ENVIRONMENT = Environment.TEST
 
+# Database
+# ------------------------------------------------------------------------------
+DATABASES["default"]["HOST"] = os.getenv("PGHOST", "localhost")  # noqa: F405
+DATABASES["default"]["PORT"] = os.getenv("PGPORT", "5432")  # noqa: F405
+DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "communaute")  # noqa: F405
+DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")  # noqa: F405
+DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: F405
+
 # S3 uploads
 # ------------------------------------------------------------------------------
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,0 +1,31 @@
+import os
+
+from lacommunaute.utils.enums import Environment
+
+from .base import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F403 F401
+
+
+# Django settings
+# ---------------
+SECRET_KEY = "v3ry_s3cr3t_k3y"
+
+ENVIRONMENT = Environment.TEST
+
+# S3 uploads
+# ------------------------------------------------------------------------------
+
+AWS_S3_ACCESS_KEY_ID = os.getenv("CELLAR_ADDON_KEY_ID", "minioadmin")
+AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_KEY_SECRET", "minioadmin")
+AWS_S3_ENDPOINT_URL = (
+    f"{os.getenv('CELLAR_ADDON_PROTOCOL', 'http')}://{os.getenv('CELLAR_ADDON_HOST', 'localhost:9000')}"
+)
+AWS_STORAGE_BUCKET_NAME = "private-bucket"
+AWS_STORAGE_BUCKET_NAME_PUBLIC = "public-bucket"
+AWS_S3_STORAGE_BUCKET_REGION = "eu-west-3"
+
+MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"
+
+# SENDINBLUE
+# ---------------------------------------
+SIB_URL = "http://test.com"
+SIB_API_KEY = "dummy-sib-api-key"

--- a/docker/django/entrypoint.sh
+++ b/docker/django/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-while ! pg_isready -h $POSTGRESQL_ADDON_HOST -p 5432; do
+while ! pg_isready -h $PGHOST -p 5432; do
     >&2 echo "Postgres is unavailable - sleeping"
     sleep 1
 done

--- a/lacommunaute/notification/emails.py
+++ b/lacommunaute/notification/emails.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from lacommunaute.notification.enums import EmailSentTrackKind
 from lacommunaute.notification.models import EmailSentTrack
+from lacommunaute.utils.enums import Environment
 
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,8 @@ def send_email(to, params, template_id, kind, bcc=None):
     if bcc:
         payload["bcc"] = bcc
 
-    if settings.DEBUG:
-        # We don't want to send emails in debug mode, payload is saved in the database
+    if settings.ENVIRONMENT == Environment.DEV:
+        # We don't want to send emails in DEV mode, payload is saved in the database
         response = httpx.Response(200, json={"message": "OK"})
     else:
         response = httpx.post(SIB_SMTP_URL, headers=headers, json=payload)

--- a/lacommunaute/notification/emails.py
+++ b/lacommunaute/notification/emails.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urljoin
 
 import httpx
 from django.conf import settings
@@ -8,6 +9,9 @@ from lacommunaute.notification.models import EmailSentTrack
 
 
 logger = logging.getLogger(__name__)
+
+SIB_SMTP_URL = urljoin(settings.SIB_URL, settings.SIB_SMTP_ROUTE)
+SIB_CONTACTS_URL = urljoin(settings.SIB_URL, settings.SIB_CONTACTS_ROUTE)
 
 
 def send_email(to, params, template_id, kind, bcc=None):
@@ -25,7 +29,7 @@ def send_email(to, params, template_id, kind, bcc=None):
         # We don't want to send emails in debug mode, payload is saved in the database
         response = httpx.Response(200, json={"message": "OK"})
     else:
-        response = httpx.post(settings.SIB_SMTP_URL, headers=headers, json=payload)
+        response = httpx.post(SIB_SMTP_URL, headers=headers, json=payload)
 
     EmailSentTrack.objects.create(
         status_code=response.status_code,
@@ -47,7 +51,7 @@ def bulk_send_user_to_list(users, list_id):
         "emptyContactsAttributes": True,
     }
     headers = {"accept": "application/json", "content-type": "application/json", "api-key": settings.SIB_API_KEY}
-    response = httpx.post(settings.SIB_CONTACTS_URL, headers=headers, json=payload)
+    response = httpx.post(SIB_CONTACTS_URL, headers=headers, json=payload)
 
     EmailSentTrack.objects.create(
         status_code=response.status_code, response=response.text, datas=payload, kind=EmailSentTrackKind.ONBOARDING

--- a/lacommunaute/notification/tasks.py
+++ b/lacommunaute/notification/tasks.py
@@ -3,7 +3,6 @@ from django.template.defaultfilters import pluralize
 from django.urls import reverse
 from django.utils import timezone
 
-from config.settings.base import NEW_MESSAGES_EMAIL_MAX_PREVIEW, SIB_NEW_MESSAGES_TEMPLATE
 from lacommunaute.forum_conversation.models import Topic
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.notification.emails import bulk_send_user_to_list, send_email
@@ -31,13 +30,13 @@ def send_messages_notifications(delay: NotificationDelay):
 
         params = {
             "email_thumbnail": (f"Vous avez {message_count_text} à découvrir sur la communauté de l'inclusion"),
-            "messages": get_serialized_messages(recipient_notifications[:NEW_MESSAGES_EMAIL_MAX_PREVIEW]),
+            "messages": get_serialized_messages(recipient_notifications[: settings.NEW_MESSAGES_EMAIL_MAX_PREVIEW]),
         }
         send_email(
             to=[{"email": recipient}],
             params=params,
             kind=EmailSentTrackKind.BULK_NOTIFS,
-            template_id=SIB_NEW_MESSAGES_TEMPLATE,
+            template_id=settings.SIB_NEW_MESSAGES_TEMPLATE,
         )
 
     notifications.update(sent_at=timezone.now())

--- a/lacommunaute/notification/tests/tests_emails.py
+++ b/lacommunaute/notification/tests/tests_emails.py
@@ -2,11 +2,11 @@ import json
 
 import httpx
 import respx
+from django.conf import settings
 from django.test import TestCase
 from faker import Faker
 
-from config.settings.base import DEFAULT_FROM_EMAIL, SIB_CONTACTS_URL, SIB_SMTP_URL
-from lacommunaute.notification.emails import bulk_send_user_to_list, send_email
+from lacommunaute.notification.emails import SIB_CONTACTS_URL, SIB_SMTP_URL, bulk_send_user_to_list, send_email
 from lacommunaute.notification.models import EmailSentTrack
 from lacommunaute.users.factories import UserFactory
 
@@ -23,7 +23,7 @@ class SendEmailTestCase(TestCase):
         cls.template_id = faker.random_int()
         cls.kind = "first_reply"
         cls.payload = {
-            "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
+            "sender": {"name": "La Communauté", "email": settings.DEFAULT_FROM_EMAIL},
             "to": cls.to,
             "params": cls.params,
             "templateId": cls.template_id,

--- a/lacommunaute/notification/tests/tests_tasks.py
+++ b/lacommunaute/notification/tests/tests_tasks.py
@@ -8,17 +8,11 @@ from django.test import TestCase
 from django.urls import reverse
 from faker import Faker
 
-from config.settings.base import (
-    DEFAULT_FROM_EMAIL,
-    SIB_CONTACTS_URL,
-    SIB_ONBOARDING_LIST,
-    SIB_SMTP_URL,
-    SIB_UNANSWERED_QUESTION_TEMPLATE,
-)
 from lacommunaute.forum_conversation.factories import (
     TopicFactory,
 )
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
+from lacommunaute.notification.emails import SIB_CONTACTS_URL, SIB_SMTP_URL
 from lacommunaute.notification.enums import NotificationDelay
 from lacommunaute.notification.factories import NotificationFactory
 from lacommunaute.notification.models import EmailSentTrack
@@ -128,7 +122,7 @@ class AddUserToListWhenRegister(TestCase):
             ],
             "emailBlacklist": False,
             "smsBlacklist": False,
-            "listIds": [SIB_ONBOARDING_LIST],
+            "listIds": [settings.SIB_ONBOARDING_LIST],
             "updateExistingContacts": True,
             "emptyContactsAttributes": True,
         }
@@ -163,10 +157,10 @@ def payload_for_staff_user_to_notify_on_unanswered_topics_fixture():
     )
     params = {"count": 1, "link": "".join(url)}
     payload = {
-        "sender": {"name": "La Communauté", "email": DEFAULT_FROM_EMAIL},
+        "sender": {"name": "La Communauté", "email": settings.DEFAULT_FROM_EMAIL},
         "to": to,
         "params": params,
-        "templateId": SIB_UNANSWERED_QUESTION_TEMPLATE,
+        "templateId": settings.SIB_UNANSWERED_QUESTION_TEMPLATE,
     }
     yield payload
 

--- a/lacommunaute/partner/migrations/0001_initial.py
+++ b/lacommunaute/partner/migrations/0001_initial.py
@@ -2,6 +2,7 @@
 
 import machina.models.fields
 import storages.backends.s3
+from django.conf import settings
 from django.db import migrations, models
 
 import lacommunaute.utils.validators
@@ -35,7 +36,9 @@ class Migration(migrations.Migration):
                     "logo",
                     models.ImageField(
                         help_text="1200x600 recommandé",
-                        storage=storages.backends.s3.S3Storage(bucket_name="private-bucket", file_overwrite=False),
+                        storage=storages.backends.s3.S3Storage(
+                            bucket_name=settings.AWS_STORAGE_BUCKET_NAME, file_overwrite=False
+                        ),
                         upload_to="logos/",
                         validators=[lacommunaute.utils.validators.validate_image_size],
                     ),

--- a/lacommunaute/users/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/users/tests/__snapshots__/tests_views.ambr
@@ -613,9 +613,9 @@
           </main>
   '''
 # ---
-# name: TestSendMagicLink.test_send_magic_link[DEV-1][send_magic_link_payload]
+# name: TestSendMagicLink.test_send_magic[PROD-True-0][send_magic_link_payload]
   '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
 # ---
-# name: TestSendMagicLink.test_send_magic_link[PROD-0][send_magic_link_payload]
+# name: TestSendMagicLink.test_send_magic[TEST-True-0][send_magic_link_payload]
   '{"sender": {"name": "La Communaut\\u00e9", "email": "noreply@inclusion.gouv.fr"}, "to": [{"email": "samuel@jackson.com"}], "params": {"display_name": "Samuel J.", "login_link": "LOGIN_LINK"}, "templateId": 31}'
 # ---

--- a/lacommunaute/users/tests/tests_views.py
+++ b/lacommunaute/users/tests/tests_views.py
@@ -18,6 +18,7 @@ from django.utils.http import urlsafe_base64_encode
 from pytest_django.asserts import assertContains
 
 from lacommunaute.forum_member.models import ForumProfile
+from lacommunaute.notification.emails import SIB_SMTP_URL
 from lacommunaute.users.enums import IdentityProvider
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.users.models import User
@@ -33,7 +34,7 @@ next_url_tuples = [("/", "/"), ("/topics/", "/topics/"), ("http://www.unallowed_
 @pytest.fixture(name="mock_respx_post_to_sib_smtp_url")
 def mock_respx_post_to_sib_smtp_url_fixture():
     with respx.mock:
-        respx.post(settings.SIB_SMTP_URL).mock(return_value=httpx.Response(200, json={"message": "OK"}))
+        respx.post(SIB_SMTP_URL).mock(return_value=httpx.Response(200, json={"message": "OK"}))
         yield
 
 

--- a/lacommunaute/users/views.py
+++ b/lacommunaute/users/views.py
@@ -20,6 +20,7 @@ from lacommunaute.notification.enums import EmailSentTrackKind
 from lacommunaute.users.enums import IdentityProvider
 from lacommunaute.users.forms import CreateUserForm, LoginForm
 from lacommunaute.users.models import User
+from lacommunaute.utils.enums import Environment
 from lacommunaute.utils.urls import clean_next_url
 
 
@@ -40,7 +41,7 @@ def send_magic_link(request, user, next_url):
         template_id=settings.SIB_MAGIC_LINK_TEMPLATE,
     )
 
-    if settings.ENVIRONMENT == "DEV":
+    if settings.ENVIRONMENT == Environment.DEV:
         message = format_html('<a href="{0}">{0}</a> sent to {1}', login_link, user.email)
         messages.success(request, message)
 

--- a/lacommunaute/utils/enums.py
+++ b/lacommunaute/utils/enums.py
@@ -9,3 +9,4 @@ class PeriodAggregation(models.TextChoices):
 class Environment(models.TextChoices):
     DEV = "DEV"
     PROD = "PROD"
+    TEST = "TEST"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,11 @@ format_js = false
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "config.settings.test"
 python_files = ["tests*.py", "test_*.py"]
-addopts = "--reuse-db --strict-markers"
+addopts = [
+    "--reuse-db",
+    "--strict-markers",
+]
+
 
 [tool.pytest.ini_options.markers]
 no_django_db = "mark tests that should not be marked with django_db."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,11 @@ ignore="T002,T003,T027,H006,H023,D018"
 max_attribute_length=200
 format_css = true
 format_js = false
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "config.settings.test"
+python_files = ["tests*.py", "test_*.py"]
+addopts = "--reuse-db --strict-markers"
+
+[tool.pytest.ini_options.markers]
+no_django_db = "mark tests that should not be marked with django_db."

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = config.settings.base
+DJANGO_SETTINGS_MODULE = config.settings.test
 python_files = tests*.py test_*.py
 addopts =
     --reuse-db

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = config.settings.test
-python_files = tests*.py test_*.py
-addopts =
-    --reuse-db
-    --strict-markers
-markers =
-    no_django_db: mark tests that should not be marked with django_db.
-

--- a/scripts/import-latest-db-backup.sh
+++ b/scripts/import-latest-db-backup.sh
@@ -23,13 +23,13 @@ echo "Going to inject DB_BACKUP_PATH=$DB_BACKUP_PATH"
 docker cp $DB_BACKUP_PATH commu_postgres:/backups
 
 echo "dropping current db"
-dropdb $POSTGRESQL_ADDON_DB -U $POSTGRESQL_ADDON_USER --if-exists --echo
+dropdb $PGDATABASE -U $PGUSER --if-exists --echo
 
 echo "creating new db"
-createdb $POSTGRESQL_ADDON_DB -O $POSTGRESQL_ADDON_USER -U $POSTGRESQL_ADDON_USER --echo
+createdb $PGDATABASE -O $PGUSER -U $PGUSER --echo
 
 echo "restoring db"
-pg_restore -U $POSTGRESQL_ADDON_USER --dbname=$POSTGRESQL_ADDON_DB --format=c --clean --no-owner $DB_BACKUP_PATH
+pg_restore -U $PGUSER --dbname=$PGDATABASE --format=c --clean --no-owner $DB_BACKUP_PATH
 
 echo "applying new migrations"
 python manage.py migrate


### PR DESCRIPTION
## Description

🎸 Isoler les `settings` de test, pour nettoyer les valeurs par défaut des `settings` de base et de dev.
🎸 Utiliser ces `settings` de test pour rendre les tests executables dès le tirage du dépôt.
🎸 Utiliser ces `settings` dans la `CI` pour harmoniser l'execution des tests en local et dans les actions  github

## Type de changement

🚧 technique

### Points d'attention

🦺 refactor de l'appel aux settings liés aux envois de mails
🦺 simplification de la gestion des routes `brevo`
🦺 harmonisation des `settings` utilisés pour envoyer le lien magique par mail ou dans les `message` django
🦺 prise en compte des noms de bucket issus des `settings` dans les fichiers de migration

📦 prerequis à la PR #857