### PR TITLE
feat(search): ajout de liens de recherche vers le site des emplois

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -347,6 +347,12 @@ DSP_FORUM_RELATED_ID = 108
 
 API_BAN_BASE_URL = "https://api-adresse.data.gouv.fr"
 
+# EMPLOI
+# ------------------------------------------------------------------------------
+EMPLOI_BASE_URL = os.getenv("EMPLOI_BASE_URL", "https://emplois.inclusion.beta.gouv.fr")
+EMPLOIS_PRESCRIBER_SEARCH = f"{EMPLOI_BASE_URL}/search/prescribers"
+EMPLOIS_COMPANY_SEARCH = f"{EMPLOI_BASE_URL}/search/employers"
+
 # MATOMO
 # ---------------------------------------
 MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL", None)

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -37,3 +37,8 @@ MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"
 # ---------------------------------------
 SIB_URL = "http://test.com"
 SIB_API_KEY = "dummy-sib-api-key"
+
+# EMPLOIS
+# ---------------------------------------
+EMPLOIS_PRESCRIBER_SEARCH = "http://test.com/prescriber/search"
+EMPLOIS_COMPANY_SEARCH = "http://test.com/company/search"

--- a/lacommunaute/search/__snapshots__/tests.ambr
+++ b/lacommunaute/search/__snapshots__/tests.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_extra_context[no_query]
+# name: test_extra_context[<lambda>-proconnected][no_query]
   '''
   <main class="s-main" id="main" role="main">
               
@@ -75,7 +75,7 @@
           </main>
   '''
 # ---
-# name: test_extra_context[no_results]
+# name: test_extra_context[<lambda>-proconnected][proconnected]
   '''
   <main class="s-main" id="main" role="main">
               
@@ -164,6 +164,227 @@
                           </div>
                       </div>
                   </div>
+                  <div class="row mt-3">
+                      <div class="col-12">
+                          <div class="c-box">
+                              <div class="row align-items-center mb-3">
+                                  <div class="col">Je recherche un emploi inclusif ?</div>
+                                  <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                      <a class="btn btn-outline-primary btn-ico btn-block matomo-event" data-matomo-action="emplois" data-matomo-category="engagement" data-matomo-option="search-prescriber" href="http://test.com/company/search?proconnect_login=true&amp;username=123" rel="nofollow">
+                                          <i class="ri-chat-new-line ri-lg"></i>
+                                          <span>Trouver une offre d'emploi</span>
+                                      </a>
+                                  </div>
+                              </div>
+                              <div class="row align-items-center">
+                                  <div class="col">Je recherche un prescripteur habilité ?</div>
+                                  <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                      <a class="btn btn-outline-primary btn-ico btn-block matomo-event" data-matomo-action="emplois" data-matomo-category="engagement" data-matomo-option="search-company" href="http://test.com/prescriber/search?proconnect_login=true&amp;username=123" rel="nofollow">
+                                          <i class="ri-chat-new-line ri-lg"></i>
+                                          <span>Trouver un prescripteur habilité</span>
+                                      </a>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_extra_context[None-anonymous][anonymous]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1>Chercher dans la communauté</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12">
+                      <div class="c-box">
+  <form action="." class="form" method="get" name="search_form">
+      <div class="form-row align-items-end">
+          <div class="col">
+  
+  <div class="form-group" id="div_id_q">
+      
+          
+              <label class="control-label" for="id_q">
+                  Rechercher par mots clés
+                  
+                      <span class="text-muted">(optional)</span>
+                  
+              </label>
+          
+          
+              <input class="form-control" id="id_q" maxlength="255" name="q" placeholder="Mots clés ou phrase" type="search" value="Bubba Gump Shrimp Co."/>
+          
+      
+      
+      
+      
+  </div>
+  </div>
+          <div class="col-auto mb-3">
+              <button class="btn btn-primary btn-ico matomo-event" data-matomo-action="search" data-matomo-category="engagement" data-matomo-option="submit_query" type="submit">
+                  <i class="ri-search-line"></i>
+                  <span>Rechercher</span>
+              </button>
+          </div>
+      </div>
+      <div class="form-row align-items-end">
+          <div class="col-auto">Rechercher dans</div>
+          <div class="col">
+              <ul class="list-inline mb-0">
+                  <li class="list-inline-item me-3"><label for="id_m_0"><input id="id_m_0" name="m" type="radio" value="all"/>
+   tout le site</label></li><li class="list-inline-item me-3"><label for="id_m_1"><input checked="" id="id_m_1" name="m" type="radio" value="TOPIC"/>
+   les échanges</label></li><li class="list-inline-item me-3"><label for="id_m_2"><input id="id_m_2" name="m" type="radio" value="FORUM"/>
+   la documentation</label></li>
+              </ul>
+          </div>
+      </div>
+  </form>
+  </div>
+                  </div>
+              </div>
+              
+                  <div class="row mt-3">
+                      <div class="col-12">
+                          <div class="c-box">
+                              
+                                  <div class="row align-items-center">
+                                      <div class="col">
+                                          <h3 class="h4 mb-0">Aucun résultat ? Posez votre question dans l'espace d'échanges !</h3>
+                                      </div>
+                                      <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                          <a class="btn btn-outline-primary btn-ico btn-block matomo-event" data-matomo-action="contribute" data-matomo-category="engagement" data-matomo-option="new_topic_after_search" href="/forum/forrest-gump-42/topic/create/" rel="nofollow">
+                                              <i class="ri-chat-new-line ri-lg"></i>
+                                              <span>Poser une question</span>
+                                          </a>
+                                      </div>
+                                  </div>
+                              
+                              
+                          </div>
+                      </div>
+                  </div>
+                  <div class="row mt-3">
+                      <div class="col-12">
+                          <div class="c-box">
+                              <div class="row align-items-center mb-3">
+                                  <div class="col">Je recherche un emploi inclusif ?</div>
+                                  <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                      <a class="btn btn-outline-primary btn-ico btn-block matomo-event" data-matomo-action="emplois" data-matomo-category="engagement" data-matomo-option="search-prescriber" href="http://test.com/company/search" rel="nofollow">
+                                          <i class="ri-chat-new-line ri-lg"></i>
+                                          <span>Trouver une offre d'emploi</span>
+                                      </a>
+                                  </div>
+                              </div>
+                              <div class="row align-items-center">
+                                  <div class="col">Je recherche un prescripteur habilité ?</div>
+                                  <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                      <a class="btn btn-outline-primary btn-ico btn-block matomo-event" data-matomo-action="emplois" data-matomo-category="engagement" data-matomo-option="search-company" href="http://test.com/prescriber/search" rel="nofollow">
+                                          <i class="ri-chat-new-line ri-lg"></i>
+                                          <span>Trouver un prescripteur habilité</span>
+                                      </a>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              
+          </div>
+      </section>
+  
+              
+          </main>
+  '''
+# ---
+# name: test_extra_context[None-anonymous][no_query]
+  '''
+  <main class="s-main" id="main" role="main">
+              
+                  
+              
+              
+              
+                  
+      <section class="s-title-01 mt-lg-5">
+          <div class="s-title-01__container container">
+              <div class="s-title-01__row row">
+                  <div class="s-title-01__col col-12">
+                      <h1>Chercher dans la communauté</h1>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12">
+                      <div class="c-box">
+  <form action="." class="form" method="get" name="search_form">
+      <div class="form-row align-items-end">
+          <div class="col">
+  
+  <div class="form-group" id="div_id_q">
+      
+          
+              <label class="control-label" for="id_q">
+                  Rechercher par mots clés
+                  
+                      <span class="text-muted">(optional)</span>
+                  
+              </label>
+          
+          
+              <input class="form-control" id="id_q" maxlength="255" name="q" placeholder="Mots clés ou phrase" type="search"/>
+          
+      
+      
+      
+      
+  </div>
+  </div>
+          <div class="col-auto mb-3">
+              <button class="btn btn-primary btn-ico matomo-event" data-matomo-action="search" data-matomo-category="engagement" data-matomo-option="submit_query" type="submit">
+                  <i class="ri-search-line"></i>
+                  <span>Rechercher</span>
+              </button>
+          </div>
+      </div>
+      <div class="form-row align-items-end">
+          <div class="col-auto">Rechercher dans</div>
+          <div class="col">
+              <ul class="list-inline mb-0">
+                  <li class="list-inline-item me-3"><label for="id_m_0"><input checked="" id="id_m_0" name="m" type="radio" value="all"/>
+   tout le site</label></li><li class="list-inline-item me-3"><label for="id_m_1"><input id="id_m_1" name="m" type="radio" value="TOPIC"/>
+   les échanges</label></li><li class="list-inline-item me-3"><label for="id_m_2"><input id="id_m_2" name="m" type="radio" value="FORUM"/>
+   la documentation</label></li>
+              </ul>
+          </div>
+      </div>
+  </form>
+  </div>
+                  </div>
+              </div>
               
           </div>
       </section>

--- a/lacommunaute/templates/forum_conversation/partials/topic_tags.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_tags.html
@@ -1,4 +1,4 @@
-{% load url_add_query %}
+{% load url_query_tags %}
 {% for tag in tags %}
     {% url_add_query request.path tag=tag.slug filter=active_filter.value as url_with_query_params %}
     <button id="filtertopics-button"

--- a/lacommunaute/templates/forum_conversation/topic_list.html
+++ b/lacommunaute/templates/forum_conversation/topic_list.html
@@ -3,7 +3,7 @@
 {% load forum_member_tags %}
 {% load forum_tracking_tags %}
 {% load forum_permission_tags %}
-{% load url_add_query %}
+{% load url_query_tags %}
 {% if forum %}
     {% get_permission 'can_download_files' forum request.user as user_can_download_files %}
 {% endif %}

--- a/lacommunaute/templates/partials/header.html
+++ b/lacommunaute/templates/partials/header.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load theme_inclusion %}
 {% load forum_member_tags %}
+{% load url_query_tags %}
 {% url 'pages:home' as home_url %}
 {% url 'forum_conversation_extension:topics' as publicforum_url %}
 {% url 'forum_extension:documentation' as documentation_url %}
@@ -97,6 +98,26 @@
                                                     <a class="dropdown-item text-primary" href="{% url 'admin:index' %}">Accéder à l'admin</a>
                                                 </li>
                                             {% endif %}
+                                            <li>
+                                                <div class="dropdown-divider"></div>
+                                            </li>
+                                            <li>
+                                                <a class="dropdown-item text-primary" href="{% url 'search:index' %}">Rechercher dans la documentation</a>
+                                            </li>
+                                            <li>
+                                                <a class="dropdown-item text-primary matomo-event"
+                                                   data-matomo-category="engagement"
+                                                   data-matomo-action="emplois"
+                                                   data-matomo-option="search-company-header"
+                                                   href="{% autologin_proconnect EMPLOIS_COMPANY_SEARCH user %}">Rechercher un emploi inclusif</a>
+                                            </li>
+                                            <li>
+                                                <a class="dropdown-item text-primary matomo-event"
+                                                   data-matomo-category="engagement"
+                                                   data-matomo-action="emplois"
+                                                   data-matomo-option="search-prescriber-header"
+                                                   href="{% autologin_proconnect EMPLOIS_PRESCRIBER_SEARCH user %}">Rechercher un prescripteur habilité</a>
+                                            </li>
                                             <li>
                                                 <div class="dropdown-divider"></div>
                                             </li>

--- a/lacommunaute/templates/partials/pagination.html
+++ b/lacommunaute/templates/partials/pagination.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load url_add_query %}
+{% load url_query_tags %}
 {% if is_paginated %}
     <ul class="m-0 pagination {{ pagination_size|default:"" }}">
         <li class="page-item {% if not page_obj.has_previous %}disabled{% endif %}">

--- a/lacommunaute/templates/search/commonindex_list.html
+++ b/lacommunaute/templates/search/commonindex_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load date_filters %}
 {% load str_filters %}
+{% load url_query_tags %}
 {% block title %}
     {% trans "Search" %}{{ block.super }}
 {% endblock %}
@@ -111,6 +112,40 @@
                                     {% include "partials/pagination.html" %}
                                 {% endwith %}
                             {% endif %}
+                        </div>
+                    </div>
+                </div>
+                <div class="row mt-3">
+                    <div class="col-12">
+                        <div class="c-box">
+                            <div class="row align-items-center mb-3">
+                                <div class="col">Je recherche un emploi inclusif ?</div>
+                                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                    <a href="{% autologin_proconnect EMPLOIS_COMPANY_SEARCH user %}"
+                                       rel="nofollow"
+                                       class="btn btn-outline-primary btn-ico btn-block matomo-event"
+                                       data-matomo-category="engagement"
+                                       data-matomo-action="emplois"
+                                       data-matomo-option="search-prescriber">
+                                        <i class="ri-chat-new-line ri-lg"></i>
+                                        <span>Trouver une offre d'emploi</span>
+                                    </a>
+                                </div>
+                            </div>
+                            <div class="row align-items-center">
+                                <div class="col">Je recherche un prescripteur habilité ?</div>
+                                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                    <a href="{% autologin_proconnect EMPLOIS_PRESCRIBER_SEARCH user %}"
+                                       rel="nofollow"
+                                       class="btn btn-outline-primary btn-ico btn-block matomo-event"
+                                       data-matomo-category="engagement"
+                                       data-matomo-action="emplois"
+                                       data-matomo-option="search-company">
+                                        <i class="ri-chat-new-line ri-lg"></i>
+                                        <span>Trouver un prescripteur habilité</span>
+                                    </a>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/lacommunaute/utils/settings_context_processors.py
+++ b/lacommunaute/utils/settings_context_processors.py
@@ -13,4 +13,6 @@ def expose_settings(request):
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
         "ENVIRONMENT": settings.ENVIRONMENT,
+        "EMPLOIS_PRESCRIBER_SEARCH": settings.EMPLOIS_PRESCRIBER_SEARCH,
+        "EMPLOIS_COMPANY_SEARCH": settings.EMPLOIS_COMPANY_SEARCH,
     }

--- a/lacommunaute/utils/templatetags/url_query_tags.py
+++ b/lacommunaute/utils/templatetags/url_query_tags.py
@@ -3,6 +3,8 @@ from urllib.parse import urlsplit, urlunsplit
 from django import template
 from django.http import QueryDict
 
+from lacommunaute.users.enums import IdentityProvider
+
 
 register = template.Library()
 
@@ -25,3 +27,10 @@ def url_add_query(url, **kwargs):
             querystring.pop(item)
     querystring.update(kwargs)
     return urlunsplit(parsed._replace(query=querystring.urlencode()))
+
+
+@register.simple_tag
+def autologin_proconnect(url, user):
+    if user.is_authenticated and user.identity_provider == IdentityProvider.PRO_CONNECT:
+        return url_add_query(url, proconnect_login="true", username=user.username)
+    return url

--- a/lacommunaute/utils/templatetags/url_query_tags.py
+++ b/lacommunaute/utils/templatetags/url_query_tags.py
@@ -15,7 +15,7 @@ def url_add_query(url, **kwargs):
     otherwise it will be appended.
 
     Usage:
-        {% load url_add_query %}
+        {% load url_query_tags %}
         {% url_add_query request.get_full_path page=2 %}
     """
     parsed = urlsplit(url)

--- a/lacommunaute/utils/tests/tests_context_processor.py
+++ b/lacommunaute/utils/tests/tests_context_processor.py
@@ -1,0 +1,18 @@
+import pytest
+from django.test import override_settings
+
+from lacommunaute.utils.enums import Environment
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [
+        (Environment.PROD, False),
+        (Environment.TEST, False),
+        (Environment.DEV, True),
+    ],
+)
+def test_prod_environment(client, db, env, expected):
+    with override_settings(ENVIRONMENT=env):
+        response = client.get("/")
+    assert ('id="debug-mode-banner"' in response.content.decode()) == expected

--- a/lacommunaute/utils/tests/tests_context_processor.py
+++ b/lacommunaute/utils/tests/tests_context_processor.py
@@ -16,3 +16,13 @@ def test_prod_environment(client, db, env, expected):
     with override_settings(ENVIRONMENT=env):
         response = client.get("/")
     assert ('id="debug-mode-banner"' in response.content.decode()) == expected
+
+
+def test_exposed_settings(client, db):
+    response = client.get("/")
+    assert "BASE_TEMPLATE" in response.context
+    assert "MATOMO_SITE_ID" in response.context
+    assert "MATOMO_BASE_URL" in response.context
+    assert "ENVIRONMENT" in response.context
+    assert "EMPLOIS_PRESCRIBER_SEARCH" in response.context
+    assert "EMPLOIS_COMPANY_SEARCH" in response.context

--- a/lacommunaute/utils/tests/tests_middleware.py
+++ b/lacommunaute/utils/tests/tests_middleware.py
@@ -1,7 +1,4 @@
-import pytest
 from django.test import TestCase, override_settings
-
-from lacommunaute.utils.enums import Environment
 
 
 class ParkingMiddlewareTest(TestCase):
@@ -16,18 +13,3 @@ class ParkingMiddlewareTest(TestCase):
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "pages/home.html")
-
-
-class TestEnvironmentSettingsMiddleware:
-    @pytest.mark.parametrize(
-        "env,expected",
-        [
-            (Environment.PROD, False),
-            (Environment.TEST, False),
-            (Environment.DEV, True),
-        ],
-    )
-    def test_prod_environment(self, client, db, env, expected):
-        with override_settings(ENVIRONMENT=env):
-            response = client.get("/")
-        assert ('id="debug-mode-banner"' in response.content.decode()) == expected

--- a/lacommunaute/utils/tests/tests_middleware.py
+++ b/lacommunaute/utils/tests/tests_middleware.py
@@ -1,15 +1,17 @@
-from django.test import TestCase, override_settings
+import pytest
+from django.test import override_settings
+from pytest_django.asserts import assertTemplateUsed
 
 
-class ParkingMiddlewareTest(TestCase):
-    @override_settings(PARKING_PAGE=True)
-    def test_parking_page_middleware(self):
-        response = self.client.get("/")
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "middleware/parking.html")
-
-    @override_settings(PARKING_PAGE=False)
-    def test_no_parking_page_middleware(self):
-        response = self.client.get("/")
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "pages/home.html")
+@pytest.mark.parametrize(
+    "parking_page, expected_template",
+    [
+        (True, "middleware/parking.html"),
+        (False, "pages/home.html"),
+    ],
+)
+def test_parking_page_middleware(client, db, parking_page, expected_template):
+    with override_settings(PARKING_PAGE=parking_page):
+        response = client.get("/")
+        assert response.status_code == 200
+        assertTemplateUsed(response, expected_template)

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -238,21 +238,21 @@ class UtilsTemplateTagsTestCase(TestCase):
         base_url = faker.url()
         # Full URL.
         context = {"url": f"{base_url}/?status=new&page=4&page=1"}
-        template = Template("{% load url_add_query %}{% url_add_query url page=2 %}")
+        template = Template("{% load url_query_tags %}{% url_add_query url page=2 %}")
         out = template.render(Context(context))
         expected = f"{base_url}/?status=new&amp;page=2"
         assert out == expected
 
         # Relative URL.
         context = {"url": "/?status=new&page=1"}
-        template = Template("{% load url_add_query %}{% url_add_query url page=22 %}")
+        template = Template("{% load url_query_tags %}{% url_add_query url page=22 %}")
         out = template.render(Context(context))
         expected = "/?status=new&amp;page=22"
         assert out == expected
 
         # Empty URL.
         context = {"url": ""}
-        template = Template("{% load url_add_query %}{% url_add_query url page=1 %}")
+        template = Template("{% load url_query_tags %}{% url_add_query url page=1 %}")
         out = template.render(Context(context))
         expected = "?page=1"
         assert out == expected

--- a/lacommunaute/utils/tests/tests_utils.py
+++ b/lacommunaute/utils/tests/tests_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from bs4 import BeautifulSoup
+from django.contrib.auth.models import AnonymousUser
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponse
@@ -22,6 +23,7 @@ from lacommunaute.forum_conversation.factories import TopicFactory
 from lacommunaute.forum_conversation.forum_attachments.factories import AttachmentFactory
 from lacommunaute.forum_file.models import PublicFile
 from lacommunaute.stats.models import ForumStat
+from lacommunaute.users.enums import IdentityProvider
 from lacommunaute.users.factories import UserFactory
 from lacommunaute.utils.date import get_last_sunday
 from lacommunaute.utils.math import percent
@@ -177,6 +179,23 @@ class TestUtilsTemplateTags:
         template = Template("{% load str_filters %}{{ text|youtube_embed }}")
         out = template.render(Context({"text": text}))
         assert out == expected
+
+    @pytest.mark.parametrize(
+        "user,expected_query_params",
+        [
+            (lambda: AnonymousUser(), ""),
+            (lambda: UserFactory(identity_provider=IdentityProvider.MAGIC_LINK), ""),
+            (lambda: UserFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT), ""),
+            (
+                lambda: UserFactory(username="abcd1234", identity_provider=IdentityProvider.PRO_CONNECT),
+                "?proconnect_login=true&amp;username=abcd1234",
+            ),
+        ],
+    )
+    def test_autologin_proconnect(self, db, user, expected_query_params):
+        template = Template("{% load url_query_tags %}{% autologin_proconnect url user %}")
+        out = template.render(Context({"url": "/test/", "user": user()}))
+        assert out == f"/test/{expected_query_params}"
 
 
 class UtilsTemplateTagsTestCase(TestCase):


### PR DESCRIPTION
## Description

🎸 ajout de 2 liens vers les recherches du site des emplois :
- `/search/prescribers`
- `/search/employers`

🎸 si l'utilisateur est connecté, et son `identity_provider` est _proconnect_, ajout des `query_params` pour le réauthentifier automatiquement sur le site des emplois. 

🎸 positionnement des liens : 
- page de recherche
- menu déroulant des utilisateurs connectés


## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/87ac5d8e-06ad-4374-8a89-9e3c32664997)

![image](https://github.com/user-attachments/assets/75ac89e4-27f6-455c-99a3-a1898848915c)

![image](https://github.com/user-attachments/assets/15a85063-3b02-41be-826d-d19284b5b661)

![image](https://github.com/user-attachments/assets/2d400239-d548-4d32-90dc-eadf6c55b4bc)
