### PR TITLE
feat: enregistrer le dernier evenement connu pour une adresse mail

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -102,6 +102,7 @@ DJANGO_MIDDLEWARE = [
     "lacommunaute.utils.middleware.ParkingPageMiddleware",
     "lacommunaute.openid_connect.middleware.ProConnectLoginMiddleware",
     "lacommunaute.notification.middleware.NotificationMiddleware",
+    "lacommunaute.users.middleware.MarkAsSeenLoggedUserMiddleware",
 ]
 
 THIRD_PARTIES_MIDDLEWARE = [

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -188,12 +188,12 @@ class ForumViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, f'id="collapsePost{self.topic.pk}')
 
-    def test_queries(self):
+    def test_numqueries(self):
         ContentType.objects.clear_cache()
 
         TopicFactory.create_batch(20, with_post=True)
         self.client.force_login(self.user)
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(23):
             self.client.get(self.url)
 
     def test_certified_post_display(self):

--- a/lacommunaute/forum_conversation/models.py
+++ b/lacommunaute/forum_conversation/models.py
@@ -12,7 +12,8 @@ from taggit.managers import TaggableManager
 from lacommunaute.forum_conversation.signals import post_create
 from lacommunaute.forum_member.shortcuts import get_forum_member_display_name
 from lacommunaute.forum_upvote.models import UpVote
-from lacommunaute.users.models import User
+from lacommunaute.users.enums import EmailLastSeenKind
+from lacommunaute.users.models import EmailLastSeen, User
 
 
 class TopicQuerySet(models.QuerySet):
@@ -155,6 +156,9 @@ class Post(AbstractPost):
         super().save(*args, **kwargs)
         if created:
             post_create.send(sender=self.__class__, instance=self)
+            EmailLastSeen.objects.seen(
+                email=self.poster.email if self.poster else self.username, kind=EmailLastSeenKind.POST
+            )
 
 
 class CertifiedPost(DatedModel):

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -737,7 +737,7 @@ class TopicViewTest(TestCase):
         self.client.force_login(self.poster)
 
         # note vincentporte : to be optimized
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(40):
             response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 

--- a/lacommunaute/forum_upvote/tests/test_upvotelistview.py
+++ b/lacommunaute/forum_upvote/tests/test_upvotelistview.py
@@ -78,5 +78,5 @@ def test_numqueries(client, db, django_assert_num_queries):
     PostFactory.create_batch(20, topic=TopicFactory(), upvoted_by=[user])
 
     # vincentporte : to be optimized
-    with django_assert_num_queries(37):
+    with django_assert_num_queries(38):
         client.get(url)

--- a/lacommunaute/notification/middleware.py
+++ b/lacommunaute/notification/middleware.py
@@ -4,6 +4,8 @@ from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
 
 from lacommunaute.notification.models import Notification
+from lacommunaute.users.enums import EmailLastSeenKind
+from lacommunaute.users.models import EmailLastSeen
 
 
 class NotificationMiddleware(MiddlewareMixin):
@@ -15,7 +17,13 @@ class NotificationMiddleware(MiddlewareMixin):
 
         try:
             uuid.UUID(notif_uuid, version=4)
+            try:
+                notification = Notification.objects.get(uuid=notif_uuid)
+            except Notification.DoesNotExist:
+                pass
+            else:
+                notification.visited_at = timezone.now()
+                notification.save()
+                EmailLastSeen.objects.seen(email=notification.recipient, kind=EmailLastSeenKind.VISITED)
         except ValueError:
             pass
-        else:
-            Notification.objects.filter(uuid=notif_uuid).update(visited_at=timezone.now())

--- a/lacommunaute/notification/tests/test_middleware.py
+++ b/lacommunaute/notification/tests/test_middleware.py
@@ -2,6 +2,7 @@ import pytest
 
 from lacommunaute.notification.factories import NotificationFactory
 from lacommunaute.notification.models import Notification
+from lacommunaute.users.models import EmailLastSeen
 
 
 @pytest.mark.parametrize(
@@ -24,6 +25,9 @@ def test_notif_param(client, db, notif_param, expected_visited_at):
         notification = Notification.objects.get(uuid=notif_param)
         notification.refresh_from_db()
         assert notification.visited_at is not None
+
+        email_last_seen = EmailLastSeen.objects.get()
+        assert email_last_seen.email == notification.recipient
 
     misc_notification.refresh_from_db()
     assert misc_notification.visited_at is None

--- a/lacommunaute/users/middleware.py
+++ b/lacommunaute/users/middleware.py
@@ -1,0 +1,15 @@
+import logging
+
+from django.utils.deprecation import MiddlewareMixin
+
+from lacommunaute.users.enums import EmailLastSeenKind
+from lacommunaute.users.models import EmailLastSeen
+
+
+logger = logging.getLogger(__name__)
+
+
+class MarkAsSeenLoggedUserMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        if request.user.is_authenticated:
+            EmailLastSeen.objects.seen(email=request.user.email, kind=EmailLastSeenKind.LOGGED)

--- a/lacommunaute/users/models.py
+++ b/lacommunaute/users/models.py
@@ -35,7 +35,12 @@ class EmailLastSeenQuerySet(models.QuerySet):
         if kind not in [kind for kind, _ in EmailLastSeenKind.choices]:
             raise ValueError(f"Invalid kind: {kind}")
 
-        return self.update_or_create(email=email, defaults={"last_seen_at": timezone.now(), "last_seen_kind": kind})
+        return EmailLastSeen.objects.bulk_create(
+            [EmailLastSeen(email=email, last_seen_at=timezone.now(), last_seen_kind=kind)],
+            update_fields=["last_seen_at", "last_seen_kind"],
+            update_conflicts=True,
+            unique_fields=["email"],
+        )
 
 
 class EmailLastSeen(models.Model):

--- a/lacommunaute/users/tests/tests_middleware.py
+++ b/lacommunaute/users/tests/tests_middleware.py
@@ -1,0 +1,22 @@
+import pytest
+
+from lacommunaute.users.enums import EmailLastSeenKind
+from lacommunaute.users.factories import UserFactory
+from lacommunaute.users.models import EmailLastSeen
+
+
+@pytest.mark.parametrize("logged", [True, False])
+def test_mark_as_seen_logged_user_middleware(client, db, logged):
+    if logged:
+        user = UserFactory()
+        client.force_login(user)
+
+    response = client.get("/")
+    assert response.status_code == 200
+
+    if logged:
+        email_last_seen = EmailLastSeen.objects.get()
+        assert email_last_seen.email == user.email
+        assert email_last_seen.last_seen_kind == EmailLastSeenKind.LOGGED
+    else:
+        assert not EmailLastSeen.objects.exists()

--- a/lacommunaute/users/tests/tests_models.py
+++ b/lacommunaute/users/tests/tests_models.py
@@ -68,3 +68,14 @@ class TestEmailLastSeenQueryset:
         email_last_seen = EmailLastSeen.objects.get()
         assert email_last_seen.last_seen_kind == kind
         assert email_last_seen.last_seen_at is not None
+
+    @pytest.mark.parametrize("email_last_seen", [None, lambda: EmailLastSeenFactory()])
+    def test_numqueries(self, db, django_assert_num_queries, email_last_seen):
+        if email_last_seen:
+            email_last_seen = email_last_seen()
+
+        email = email_last_seen.email if email_last_seen else EMAIL
+        kind = email_last_seen.last_seen_kind if email_last_seen else EmailLastSeenKind.POST
+
+        with django_assert_num_queries(1):
+            EmailLastSeen.objects.seen(email=email, kind=kind)


### PR DESCRIPTION
## Description

🎸 Creer ou mettre à jour `EmailLastSeen` lors des évènements suivants :
* navigation d'un utilisateur authentifié : dans un `middleware` dedié
* creation d'un `Post`/`Topic` : dans la méthode `save` du modèle `Post` 
* click sur une notification email : dans le middleware `NotificationMiddleware` de suivi des urls dans les mails de notification


## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique

### Points d'attention

🦺 Les mises à jour de `Post` ne déclenche plus de mise à jour de `EmailLastSeen` pour éviter la détérioration de données en cas de `save` massif sur des instances existantes du modèle `Post`
🦺 Creation d'un `DSP`, d'un `UpVote` ou d'un `Event`, les vues sont en `LoginRequiredOnly`. L'enregistrement du passage de l'utilisateur est donc  déjà enregistré par `MarkAsSeenLoggedUserMiddleware`
🦺 prérequis #891 et #892 




