### PR TITLE
chore: televersement des fichiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,11 @@ jobs:
         run: pytest --numprocesses=logical --create-db
         env:
           DJANGO_DEBUG: True
+      - name: 🚀 test S3 compliance
+        env:
+          CELLAR_ADDON_KEY_ID: ${{ secrets.REVIEW_CELLAR_ADDON_KEY_ID }}
+          CELLAR_ADDON_KEY_SECRET: ${{ secrets.REVIEW_CELLAR_ADDON_KEY_SECRET }}
+          CELLAR_ADDON_HOST: cellar-c2.services.clever-cloud.com
+          CELLAR_ADDON_PROTOCOL: https
+        run: |
+          pytest lacommunaute/utils/tests/tests_live_cellar.py --create-db

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,5 +1,6 @@
 import os
 
+from botocore.config import Config
 from dotenv import load_dotenv
 from machina import MACHINA_MAIN_STATIC_DIR, MACHINA_MAIN_TEMPLATE_DIR
 
@@ -274,6 +275,13 @@ AWS_S3_ENDPOINT_URL = f"{os.getenv('CELLAR_ADDON_PROTOCOL', 'https')}://{os.gete
 AWS_STORAGE_BUCKET_NAME = os.getenv("S3_STORAGE_BUCKET_NAME")
 AWS_STORAGE_BUCKET_NAME_PUBLIC = os.getenv("S3_STORAGE_BUCKET_NAME_PUBLIC")
 AWS_S3_STORAGE_BUCKET_REGION = os.getenv("S3_STORAGE_BUCKET_REGION")
+# CleverCloud S3 implementation does not support recent data integrity features from AWS.
+# https://github.com/boto/boto3/issues/4392
+# https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
+AWS_S3_CLIENT_CONFIG = Config(
+    request_checksum_calculation="when_required",
+    response_checksum_validation="when_required",
+)
 
 # MEDIA CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -27,8 +27,8 @@ AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_KEY_SECRET", "minioadmin")
 AWS_S3_ENDPOINT_URL = (
     f"{os.getenv('CELLAR_ADDON_PROTOCOL', 'http')}://{os.getenv('CELLAR_ADDON_HOST', 'localhost:9000')}"
 )
-AWS_STORAGE_BUCKET_NAME = "private-bucket"
-AWS_STORAGE_BUCKET_NAME_PUBLIC = "public-bucket"
+AWS_STORAGE_BUCKET_NAME = "c3-django-review-bucket"
+AWS_STORAGE_BUCKET_NAME_PUBLIC = "c3-django-review-bucket-public"
 AWS_S3_STORAGE_BUCKET_REGION = "eu-west-3"
 
 MEDIA_URL = f"{AWS_S3_ENDPOINT_URL}/"

--- a/lacommunaute/utils/tests/tests_live_cellar.py
+++ b/lacommunaute/utils/tests/tests_live_cellar.py
@@ -1,0 +1,40 @@
+import os
+
+import boto3
+import pytest
+from botocore.config import Config
+from django.conf import settings
+
+from lacommunaute.forum.factories import ForumFactory
+from lacommunaute.forum.models import Forum
+
+
+# CleverCloud S3 implementation does not support recent data integrity features from AWS.
+# https://github.com/boto/boto3/issues/4392
+# https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
+#
+# This test is here to ensure that file operations are ok on live cellar, to prevent
+# future failure.
+#
+@pytest.mark.skipif(os.getenv("CELLAR_ADDON_KEY_ID") is None, reason="Not using Cellar")
+def test_e2e_file_can_be_uploaded_to_cellar(db):
+    ForumFactory(with_image=True)
+    assert Forum.objects.exists()
+
+
+#
+# This test is expected not fail when live cellar conf will accept the integrity protection.
+# At that time, `Config()` in `base.py` should be clean up.
+#
+@pytest.mark.skipif(os.getenv("CELLAR_ADDON_KEY_ID") is None, reason="Not using Cellar")
+@pytest.mark.xfail
+def test_cellar_does_not_support_checksum_validation():
+    client = boto3.client(
+        "s3",
+        endpoint_url=settings.AWS_S3_ENDPOINT_URL,
+        aws_access_key_id=settings.AWS_S3_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_S3_SECRET_ACCESS_KEY,
+        region_name=settings.AWS_S3_STORAGE_BUCKET_REGION,
+        config=Config(),
+    )
+    client.put_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Body=b"", Key="file")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "python-dotenv>=1.0",
     "psycopg>=3.2",
     "django-machina>=1.2.0",
-    "boto3<1.36",
+    "boto3>=1.36",
     "django-storages>=1.14",
     "httpx>=0.28",
     "django-compressor>=4.5",

--- a/uv.lock
+++ b/uv.lock
@@ -47,30 +47,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.35.99"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/99/3e8b48f15580672eda20f33439fc1622bd611f6238b6d05407320e1fb98c/boto3-1.35.99.tar.gz", hash = "sha256:e0abd794a7a591d90558e92e29a9f8837d25ece8e3c120e530526fe27eba5fca", size = 111028 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/03/43244d4c6b67f34a979d2805ebb4f63c29b9aef3683ad179470fea52a5f3/boto3-1.37.19.tar.gz", hash = "sha256:c69c90500f18fd72d782d1612170b7d3db9a98ed51a4da3bebe38e693497ebf8", size = 111363 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/77/8bbca82f70b062181cf0ae53fd43f1ac6556f3078884bfef9da2269c06a3/boto3-1.35.99-py3-none-any.whl", hash = "sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71", size = 139178 },
+    { url = "https://files.pythonhosted.org/packages/e6/bb/7f3d90cc732c8c2f0dc971fa910b601f3c9bbe56df518f037653baf8ade3/boto3-1.37.19-py3-none-any.whl", hash = "sha256:fbfc2c43ad686b63c8aa02aee634c269f856eed68941d8e570cc45950be52130", size = 139560 },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.35.99"
+version = "1.37.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/9c/1df6deceee17c88f7170bad8325aa91452529d683486273928eecfd946d8/botocore-1.35.99.tar.gz", hash = "sha256:1eab44e969c39c5f3d9a3104a0836c24715579a455f12b3979a31d7cde51b3c3", size = 13490969 }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/4a/cf22a677045a02cf769d8126ce25572695508e4bd5d7f6fe984dc5d23c76/botocore-1.37.19.tar.gz", hash = "sha256:eadcdc37de09df25cf1e62e8106660c61f60a68e984acfc1a8d43fb6267e53b8", size = 13667634 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/dd/d87e2a145fad9e08d0ec6edcf9d71f838ccc7acdd919acc4c0d4a93515f8/botocore-1.35.99-py3-none-any.whl", hash = "sha256:b22d27b6b617fc2d7342090d6129000af2efd20174215948c0d7ae2da0fab445", size = 13293216 },
+    { url = "https://files.pythonhosted.org/packages/b4/10/f2482186a83deb8fc45cf46e5455e501e0b2db9565251e66998a80b89aaf/botocore-1.37.19-py3-none-any.whl", hash = "sha256:6e1337e73a6b8146c1ec20a6a72d67e2809bd4c0af076431fe6e1561e0c89415", size = 13429649 },
 ]
 
 [[package]]
@@ -693,7 +693,7 @@ wheels = [
 
 [[package]]
 name = "lacommunaute"
-version = "2.21.0"
+version = "2.22.0"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
@@ -742,7 +742,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = "<1.36" },
+    { name = "boto3", specifier = ">=1.36" },
     { name = "django", specifier = ">=5.1" },
     { name = "django-compressor", specifier = ">=4.5" },
     { name = "django-csp", specifier = ">=3.8" },
@@ -1228,14 +1228,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.10.4"
+version = "0.11.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7", size = 145287 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/ec/aa1a215e5c126fe5decbee2e107468f51d9ce190b9763cb649f76bb45938/s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679", size = 148419 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e", size = 83175 },
+    { url = "https://files.pythonhosted.org/packages/86/62/8d3fc3ec6640161a5649b2cddbbf2b9fa39c92541225b33f117c37c5a2eb/s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d", size = 84412 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

🔴  Tentative de mise à jour de `boto3` et `botocore` > 1.36
⚠️ L'implémentation S3 du PAAS CleverCloud ne supporte pas la nouvelle fonctionnalité de fonctions d'intégrité des données mise en place par AWS à partir de la 1.36 : [boto3 Issue 4392](https://github.com/boto/boto3/issues/4392), [boto3 Issue 4398](https://github.com/boto/boto3/issues/4398#issuecomment-2619946229)
⚠️ `minio` utilisé dans la `CI` et les tests en local supporte cette nouvelle fonctionnalité, et donc ne cassent pas.

🟢 desactivaition de la fonction d'intégrité des données
🟢 ajout d'un test activé par la `CI` uniquement pour contrôler la compatibilité entre l'app `django` et le `cellar` utilisé en production
🟢 ajout d'un test cassant tant que le `cellar` ne supporte pas le contrôle d'intégrité, en vue de le réactiver dès que compatible

## Type de changement

🚧 technique

