### PR TITLE
feat: supprimer les traces d'envoi d'emails de plus de 90 jours

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -8,5 +8,6 @@
     "*/15 7-21 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications asap",
     "20 6 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications day",
     "10 6-22 * * * $ROOT/clevercloud/run_management_command.sh add_user_to_list_when_register",
+    "0 12  * * 1 $ROOT/clevercloud/run_management_command.sh delete_old_email_sent_tracks",
     "30 13 * * 1-5 $ROOT/clevercloud/run_management_command.sh send_notifs_on_unanswered_topics"
 ]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -323,6 +323,10 @@ LOGGING = {
             "handlers": ["console"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
         },
+        "commands": {
+            "handlers": ["console"],
+            "level": os.getenv("COMMANDS_LOG_LEVEL", "INFO"),
+        },
     },
 }
 

--- a/lacommunaute/notification/admin.py
+++ b/lacommunaute/notification/admin.py
@@ -7,7 +7,7 @@ from lacommunaute.notification.models import EmailSentTrack, Notification
 @admin.register(EmailSentTrack)
 class EmailSentTrackAdmin(admin.ModelAdmin):
     list_display = ("kind", "created", "status_code")
-    list_filter = ("kind",)
+    list_filter = ("kind", "status_code")
 
 
 class BaseNotificationListFilter(admin.SimpleListFilter):

--- a/lacommunaute/notification/factories.py
+++ b/lacommunaute/notification/factories.py
@@ -9,14 +9,17 @@ from faker import Faker
 from lacommunaute.forum_conversation.factories import AnonymousPostFactory, TopicFactory
 from lacommunaute.notification.enums import EmailSentTrackKind, NotificationDelay
 from lacommunaute.notification.models import EmailSentTrack, Notification
+from lacommunaute.utils.factory_boy import AutoNowAddOverrideMixin
 
 
 faker = Faker()
 
 
-class EmailSentTrackFactory(factory.django.DjangoModelFactory):
-    status_code = faker.pyint()
-    response = faker.text()
+class EmailSentTrackFactory(AutoNowAddOverrideMixin, factory.django.DjangoModelFactory):
+    created = factory.LazyFunction(timezone.now)
+    updated = factory.LazyFunction(timezone.now)
+    status_code = factory.Faker("random_int", min=200, max=500)
+    response = factory.Faker("text")
     datas = {"text": faker.text()}
     kind = EmailSentTrackKind.FIRST_REPLY
 

--- a/lacommunaute/notification/management/commands/delete_old_email_sent_tracks.py
+++ b/lacommunaute/notification/management/commands/delete_old_email_sent_tracks.py
@@ -1,0 +1,16 @@
+from logging import getLogger
+
+from django.core.management.base import BaseCommand
+
+from lacommunaute.notification.models import EmailSentTrack
+
+
+logger = getLogger("commands")
+
+
+class Command(BaseCommand):
+    help = "Supprimer les anciens enregistrements EmailSentTrack"
+
+    def handle(self, *args, **options):
+        nb_deleted = EmailSentTrack.objects.delete_old_records()
+        logger.info("%s enregistrements EmailSentTrack supprimés", nb_deleted)

--- a/lacommunaute/notification/models.py
+++ b/lacommunaute/notification/models.py
@@ -2,12 +2,20 @@ import uuid
 from itertools import groupby
 from operator import attrgetter
 
+from dateutil.relativedelta import relativedelta
 from django.db import models
 from django.db.models import F
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from machina.models.abstract_models import DatedModel
 
 from lacommunaute.notification.enums import EmailSentTrackKind, NotificationDelay
+
+
+class EmailSentTrackQuerySet(models.QuerySet):
+    def delete_old_records(self):
+        nb, _ = self.filter(created__lt=timezone.now() - relativedelta(days=90)).delete()
+        return nb
 
 
 class EmailSentTrack(DatedModel):
@@ -17,6 +25,8 @@ class EmailSentTrack(DatedModel):
     kind = models.CharField(
         verbose_name="type", choices=EmailSentTrackKind.choices, max_length=20, null=False, blank=False
     )
+
+    objects = EmailSentTrackQuerySet().as_manager()
 
     class Meta:
         verbose_name = "trace des emails envoyés"

--- a/lacommunaute/notification/tests/tests_management_commands.py
+++ b/lacommunaute/notification/tests/tests_management_commands.py
@@ -1,0 +1,12 @@
+from dateutil.relativedelta import relativedelta
+from django.core.management import call_command
+from django.utils import timezone
+
+from lacommunaute.notification.factories import EmailSentTrackFactory
+from lacommunaute.notification.models import EmailSentTrack
+
+
+def test_delete_old_email_sent_tracks(db):
+    EmailSentTrackFactory(created=timezone.now() - relativedelta(days=90))
+    call_command("delete_old_email_sent_tracks")
+    assert EmailSentTrack.objects.count() == 0

--- a/lacommunaute/notification/tests/tests_models.py
+++ b/lacommunaute/notification/tests/tests_models.py
@@ -1,14 +1,26 @@
 import pytest
+from dateutil.relativedelta import relativedelta
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError
 from django.db.models import F
 from django.test import TestCase
+from django.utils import timezone
 
 from lacommunaute.forum_conversation.factories import TopicFactory
 from lacommunaute.notification.enums import EmailSentTrackKind
-from lacommunaute.notification.factories import NotificationFactory
+from lacommunaute.notification.factories import EmailSentTrackFactory, NotificationFactory
 from lacommunaute.notification.models import EmailSentTrack, Notification
 from lacommunaute.users.factories import UserFactory
+
+
+class TestEmailSentTrackQuerySet:
+    def test_delete_old_records(self, db):
+        _ = [EmailSentTrackFactory(created=timezone.now() - relativedelta(days=nb_days)) for nb_days in range(89, 92)]
+
+        EmailSentTrack.objects.delete_old_records()
+
+        email_sent_track = EmailSentTrack.objects.get()
+        assert email_sent_track.created >= timezone.now() - relativedelta(days=90)
 
 
 class EmailSentTrackModelTest(TestCase):

--- a/lacommunaute/utils/factory_boy.py
+++ b/lacommunaute/utils/factory_boy.py
@@ -1,0 +1,15 @@
+class AutoNowAddOverrideMixin:
+    """This mixin allows you to override fields with `auto_now=True`"""
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        auto_now_add_desactivated = []
+        for field in model_class._meta.get_fields():
+            if getattr(field, "auto_now_add", False) and kwargs.get(field.name):
+                field.auto_now_add = False
+                auto_now_add_desactivated.append(field)
+        try:
+            return super()._create(model_class, *args, **kwargs)
+        finally:
+            for field in auto_now_add_desactivated:
+                field.auto_now_add = True


### PR DESCRIPTION
## Description

🎸 L'application trace dans `EmailSentTrack` les appels à `brevo` et le code retour de leur API. Ces objets contiennent des données visées par le champ de la RGPD. Leur seul objectif est de pouvoir identifier l'apparition d'un problème lors de l'appel à l'API. Elles ne sont pas utilisées par ailleurs. Supprimons les au bout de 90 jours.

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🚧 technique

### Points d'attention

🦺 creation d'un nouveau logger. sera revu avec la mise en place de datadog (yc un json formatter)
🦺  ajout d'un filtre dans l'admin sur le `status_code` de l'api `brevo`

