### PR TITLE
feat: masquer le filtre sur les reponses certifiees

### DIFF
--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -378,24 +378,6 @@ class ForumViewTest(TestCase):
             with self.subTest(topic):
                 self.assertNotContains(response, topic.subject)
 
-    def test_queryset_for_certified_topics(self):
-        response = self.client.get(self.url + f"?filter={Filters.CERTIFIED.value}")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context_data["paginator"].count, 0)
-        self.assertEqual(response.context_data["active_filter"], Filters.CERTIFIED)
-
-        certified_topic = TopicFactory(with_post=True, with_certified_post=True, forum=self.forum)
-
-        response = self.client.get(self.url + f"?filter={Filters.CERTIFIED.value}")
-        self.assertEqual(response.context_data["paginator"].count, 1)
-        self.assertContains(response, certified_topic.subject, status_code=200)
-        self.assertContains(response, certified_topic.certified_post.post.content.raw[:100])
-        self.assertEqual(response.context_data["active_filter"], Filters.CERTIFIED)
-
-        for topic in Topic.objects.exclude(id=certified_topic.id):
-            with self.subTest(topic):
-                self.assertNotContains(response, topic.subject)
-
     def test_banner_display_on_subcategory_forum(self):
         category_forum = CategoryForumFactory(with_child=True, with_public_perms=True)
         forum = category_forum.get_children().first()

--- a/lacommunaute/forum_conversation/enums.py
+++ b/lacommunaute/forum_conversation/enums.py
@@ -4,4 +4,3 @@ from django.db import models
 class Filters(models.TextChoices):
     ALL = "ALL", "les plus récentes"
     NEW = "NEW", "en attente de réponse"
-    CERTIFIED = "CERTIFIED", "avec une réponse certifiée"

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -86,10 +86,6 @@
                                       <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=NEW&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">en attente de réponse</button>
                                   </li>
                               
-                                  <li>
-                                      <button class="dropdown-item matomo-event" data-matomo-action="filter" data-matomo-category="engagement" data-matomo-option="topics" hx-get="/topics/?filter=CERTIFIED&amp;tag=tag" hx-push-url="true" hx-swap="outerHTML" hx-target="#topicsarea" id="filter-ontag-button">avec une réponse certifiée</button>
-                                  </li>
-                              
                           </ul>
                       </div>
   '''

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -852,11 +852,6 @@ class TestTopicListView:
                 lambda forum: TopicFactory(forum=forum, with_post=True),
                 lambda forum: TopicFactory(forum=forum, with_post=True, answered=True),
             ),
-            (
-                "CERTIFIED",
-                lambda forum: TopicFactory(with_post=True, with_certified_post=True, forum=forum),
-                lambda forum: TopicFactory(forum=forum, with_post=True),
-            ),
         ],
     )
     def test_queryset_on_filter(
@@ -870,8 +865,6 @@ class TestTopicListView:
         assert expected_topic in response.context["topics"]
         if unexpected_topic:
             assert unexpected_topic not in response.context["topics"]
-        if filter == "CERTIFIED":
-            assert expected_topic.certified_post.post.content.raw[:100] in response.content.decode()
         content = parse_response_to_soup(response, selector="#topic-list-filter-header")
         assert str(content) == snapshot(name=f"{filter}-tagged_topics")
 

--- a/lacommunaute/forum_conversation/view_mixins.py
+++ b/lacommunaute/forum_conversation/view_mixins.py
@@ -13,8 +13,6 @@ class FilteredTopicsListViewMixin:
 
         if filter == Filters.NEW:
             qs = qs.unanswered()
-        elif filter == Filters.CERTIFIED:
-            qs = qs.filter(certified_post__isnull=False)
 
         if self.get_tag():
             qs = qs.filter(tags=self.get_tag())


### PR DESCRIPTION
## Description

🎸 La dernière réponse `certifiée` date de avril 2023. Masquons ce filtre avant de décider de supprimer intégralement cette fonctionnalité

## Type de changement

🎨 changement d'UI

![image](https://github.com/user-attachments/assets/0be16934-175b-4b3b-88f5-9cd84c70b128)
