### PR TITLE
feat: extension des droits des utilisateurs de l'équipe - Documentation et Partenaires

### DIFF
--- a/lacommunaute/forum/tests/test_categoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_categoryforum_createview.py
@@ -22,16 +22,11 @@ def test_user_access(client, db):
     user.is_staff = True
     user.save()
     response = client.get(url)
-    assert response.status_code == 403
-
-    user.is_superuser = True
-    user.save()
-    response = client.get(url)
     assert response.status_code == 200
 
 
 def test_form_title_and_context_data(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     url = reverse("forum_extension:create_category")
     response = client.get(url)
     assertContains(response, "Créer une nouvelle catégorie documentaire")
@@ -39,7 +34,7 @@ def test_form_title_and_context_data(client, db):
 
 
 def test_success_url(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     url = reverse("forum_extension:create_category")
     response = client.post(url, data={"name": "Test", "description": "Test", "short_description": "Test"})
     assert response.status_code == 302
@@ -47,7 +42,7 @@ def test_success_url(client, db):
 
 
 def test_create_category_with_perms(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     url = reverse("forum_extension:create_category")
     response = client.post(url, data={"name": "Test", "description": "Test", "short_description": "Test"})
     assert response.status_code == 302

--- a/lacommunaute/forum/tests/test_categoryforum_listview.py
+++ b/lacommunaute/forum/tests/test_categoryforum_listview.py
@@ -38,7 +38,7 @@ def test_display_create_category_button(client, db):
     response = client.get(url)
     assertNotContains(response, reverse("forum_extension:create_category"), status_code=200)
 
-    user.is_superuser = True
+    user.is_staff = True
     user.save()
     response = client.get(url)
     assertContains(response, reverse("forum_extension:create_category"), status_code=200)

--- a/lacommunaute/forum/tests/test_forum_updateview.py
+++ b/lacommunaute/forum/tests/test_forum_updateview.py
@@ -48,16 +48,11 @@ def test_user_access(client, db):
     user.is_staff = True
     user.save()
     response = client.get(url)
-    assert response.status_code == 403
-
-    user.is_superuser = True
-    user.save()
-    response = client.get(url)
     assert response.status_code == 200
 
 
 def test_context_data(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     forum = ForumFactory()
     url = reverse("forum_extension:edit_forum", kwargs={"pk": forum.pk, "slug": forum.slug})
     response = client.get(url)
@@ -66,7 +61,7 @@ def test_context_data(client, db):
 
 
 def test_update_forum_image(client, db, fake_image):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     forum = CategoryForumFactory(with_child=True).get_children().first()
     url = reverse("forum_extension:edit_forum", kwargs={"pk": forum.pk, "slug": forum.slug})
 
@@ -89,7 +84,7 @@ def test_update_forum_image(client, db, fake_image):
 
 
 def test_certified_forum(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     forum = CategoryForumFactory(with_child=True).get_children().first()
     url = reverse("forum_extension:edit_forum", kwargs={"pk": forum.pk, "slug": forum.slug})
 
@@ -109,7 +104,7 @@ def test_certified_forum(client, db):
 
 
 def test_selected_tags_are_preloaded(client, db, reset_tag_sequence, snapshot):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     forum = ForumFactory(with_tags=["iae", "siae", "prescripteur"])
     Tag.objects.create(name="undesired_tag")
     url = reverse("forum_extension:edit_forum", kwargs={"pk": forum.pk, "slug": forum.slug})
@@ -124,7 +119,7 @@ def test_selected_tags_are_preloaded(client, db, reset_tag_sequence, snapshot):
 
 
 def test_added_tags_are_saved(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     forum = ForumFactory()
 
     Tag.objects.bulk_create([Tag(name=tag, slug=tag) for tag in [faker.word() for _ in range(3)]])
@@ -149,7 +144,7 @@ def test_added_tags_are_saved(client, db):
 
 
 def test_update_forum_without_tag(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     forum = ForumFactory()
     url = reverse("forum_extension:edit_forum", kwargs={"pk": forum.pk, "slug": forum.slug})
     response = client.post(
@@ -179,7 +174,7 @@ def test_select_partner(client, db, initial_partner, post_partner):
     initial_partner = initial_partner()
     post_partner = post_partner()
     forum = ForumFactory(partner=initial_partner)
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
 
     url = reverse("forum_extension:edit_forum", kwargs={"pk": forum.pk, "slug": forum.slug})
     response = client.post(

--- a/lacommunaute/forum/tests/test_subcategoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_subcategoryforum_createview.py
@@ -24,16 +24,11 @@ def test_user_access(client, db):
     user.is_staff = True
     user.save()
     response = client.get(url)
-    assert response.status_code == 403
-
-    user.is_superuser = True
-    user.save()
-    response = client.get(url)
     assert response.status_code == 200
 
 
 def test_form_title_and_context_datas(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     category_forum = CategoryForumFactory()
     url = reverse("forum_extension:create_subcategory", kwargs={"pk": category_forum.pk})
     response = client.get(url)
@@ -44,7 +39,7 @@ def test_form_title_and_context_datas(client, db):
 
 
 def test_success_url(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     category_forum = CategoryForumFactory()
     url = reverse("forum_extension:create_subcategory", kwargs={"pk": category_forum.pk})
     response = client.post(url, data={"name": "Test", "description": "Test", "short_description": "Test"})
@@ -55,7 +50,7 @@ def test_success_url(client, db):
 
 
 def test_create_subcategory_with_perms(client, db):
-    client.force_login(UserFactory(is_superuser=True))
+    client.force_login(UserFactory(is_staff=True))
     category_forum = CategoryForumFactory()
     url = reverse("forum_extension:create_subcategory", kwargs={"pk": category_forum.pk})
     response = client.post(url, data={"name": "Test", "description": "Test", "short_description": "Test"})

--- a/lacommunaute/forum/tests/tests_views.py
+++ b/lacommunaute/forum/tests/tests_views.py
@@ -282,7 +282,7 @@ class ForumViewTest(TestCase):
             response, reverse("forum_extension:forum", kwargs={"pk": child_forum.pk, "slug": child_forum.slug})
         )
 
-    def test_show_add_forum_button_for_superuser_if_forum_is_category_type(self):
+    def test_show_add_forum_button_for_staff_if_forum_is_category_type(self):
         forum = CategoryForumFactory(with_public_perms=True, with_child=True)
         url = reverse("forum_extension:forum", kwargs={"pk": forum.pk, "slug": forum.slug})
 
@@ -293,7 +293,7 @@ class ForumViewTest(TestCase):
             response, reverse("forum_extension:create_subcategory", kwargs={"pk": forum.pk}), status_code=200
         )
 
-        user.is_superuser = True
+        user.is_staff = True
         user.save()
         response = self.client.get(url)
         self.assertContains(
@@ -340,11 +340,7 @@ class ForumViewTest(TestCase):
         self.assertNotContains(response, url)
 
         self.user.is_staff = True
-        self.user.save()
-        response = self.client.get(self.url)
-        self.assertNotContains(response, url)
 
-        self.user.is_superuser = True
         self.user.save()
         response = self.client.get(self.url)
         self.assertContains(response, url)
@@ -623,7 +619,7 @@ class TestDocumentationCategoryForumContent:
         # require superuser permission
         assert len(content.select("#add-documentation-to-category-control")) == 0
 
-        client.force_login(UserFactory(is_superuser=True))
+        client.force_login(UserFactory(is_staff=True))
         response = client.get(documentation_forum.parent.get_absolute_url())
         content = parse_response_to_soup(response)
 

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -125,7 +125,7 @@ class ForumUpdateView(UserPassesTestMixin, UpdateView):
     model = Forum
 
     def test_func(self):
-        return self.request.user.is_superuser
+        return self.request.user.is_staff
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -147,7 +147,7 @@ class BaseCategoryForumCreateView(UserPassesTestMixin, CreateView):
     form_class = ForumForm
 
     def test_func(self):
-        return self.request.user.is_superuser
+        return self.request.user.is_staff
 
     def form_valid(self, form):
         response = super().form_valid(form)

--- a/lacommunaute/partner/tests/__snapshots__/tests_partner_detailview.ambr
+++ b/lacommunaute/partner/tests/__snapshots__/tests_partner_detailview.ambr
@@ -98,8 +98,6 @@
                           <h1 class="mb-0">Best Partner Ever</h1>
                       </div>
                       
-                          <a href="/partenaires/best-partner-ever-[PK of Partner]/update/"><small>Mettre à jour</small></a>
-                      
                       <h2 class="mt-3">short description for SEO</h2>
                   </div>
               </div>

--- a/lacommunaute/partner/tests/tests_partner_createview.py
+++ b/lacommunaute/partner/tests/tests_partner_createview.py
@@ -10,13 +10,13 @@ def url_fixture():
     return reverse("partner:create")
 
 
-@pytest.fixture(name="superuser")
-def superuser_fixture():
-    return UserFactory(is_superuser=True)
+@pytest.fixture(name="saff_user")
+def staff_user_fixture():
+    return UserFactory(is_staff=True)
 
 
 @pytest.mark.parametrize(
-    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
+    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_staff=True), 200)]
 )
 def test_user_passes_test_mixin(client, db, url, user, status_code):
     if user:
@@ -25,8 +25,8 @@ def test_user_passes_test_mixin(client, db, url, user, status_code):
     assert response.status_code == status_code
 
 
-def test_view(client, db, url, superuser):
-    client.force_login(superuser)
+def test_view(client, db, url, saff_user):
+    client.force_login(saff_user)
     response = client.get(url)
     assert response.status_code == 200
     assert response.context["title"] == "Créer une nouvelle page partenaire"
@@ -34,8 +34,8 @@ def test_view(client, db, url, superuser):
     assert list(response.context["form"].fields.keys()) == ["name", "short_description", "description", "logo", "url"]
 
 
-def test_post_partner(client, db, url, superuser):
-    client.force_login(superuser)
+def test_post_partner(client, db, url, saff_user):
+    client.force_login(saff_user)
     data = {
         "name": "Test",
         "short_description": "Short description",

--- a/lacommunaute/partner/tests/tests_partner_listview.py
+++ b/lacommunaute/partner/tests/tests_partner_listview.py
@@ -31,7 +31,7 @@ def test_pagination(client, db, snapshot, url):
 
 @pytest.mark.parametrize(
     "user,link_is_visible",
-    [(None, False), (lambda: UserFactory(), False), (lambda: UserFactory(is_superuser=True), True)],
+    [(None, False), (lambda: UserFactory(), False), (lambda: UserFactory(is_staff=True), True)],
 )
 def test_link_to_createview(client, db, url, user, link_is_visible):
     if user:

--- a/lacommunaute/partner/tests/tests_partner_updateview.py
+++ b/lacommunaute/partner/tests/tests_partner_updateview.py
@@ -15,13 +15,13 @@ def url_fixture(partner):
     return reverse("partner:update", kwargs={"pk": partner.id, "slug": partner.slug})
 
 
-@pytest.fixture(name="superuser")
-def superuser_fixture():
-    return UserFactory(is_superuser=True)
+@pytest.fixture(name="saff_user")
+def saff_user():
+    return UserFactory(is_staff=True)
 
 
 @pytest.mark.parametrize(
-    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_superuser=True), 200)]
+    "user,status_code", [(None, 302), (lambda: UserFactory(), 403), (lambda: UserFactory(is_staff=True), 200)]
 )
 def test_user_passes_test_mixin(client, db, url, user, status_code):
     if user:
@@ -30,8 +30,8 @@ def test_user_passes_test_mixin(client, db, url, user, status_code):
     assert response.status_code == status_code
 
 
-def test_view(client, db, url, superuser, partner):
-    client.force_login(superuser)
+def test_view(client, db, url, saff_user, partner):
+    client.force_login(saff_user)
     response = client.get(url)
     assert response.status_code == 200
     assert response.context["title"] == f"Modifier la page {partner.name}"
@@ -39,8 +39,8 @@ def test_view(client, db, url, superuser, partner):
     assert list(response.context["form"].fields.keys()) == ["name", "short_description", "description", "logo", "url"]
 
 
-def test_post_partner(client, db, url, superuser, partner):
-    client.force_login(superuser)
+def test_post_partner(client, db, url, saff_user, partner):
+    client.force_login(saff_user)
     data = {
         "name": "Test",
         "short_description": "Short description",

--- a/lacommunaute/partner/views.py
+++ b/lacommunaute/partner/views.py
@@ -34,7 +34,7 @@ class PartnerCreateUpdateMixin(UserPassesTestMixin):
     form_class = PartnerForm
 
     def test_func(self):
-        return self.request.user.is_superuser
+        return self.request.user.is_staff
 
     def get_success_url(self):
         return reverse("partner:detail", kwargs={"pk": self.object.pk, "slug": self.object.slug})

--- a/lacommunaute/templates/forum/category_forum_list.html
+++ b/lacommunaute/templates/forum/category_forum_list.html
@@ -53,7 +53,7 @@
             </div>
         </div>
     </section>
-    {% if user.is_superuser %}
+    {% if user.is_staff %}
         <section class="s-section">
             <div class="s-section__container container">
                 <div class="s-section__row row">

--- a/lacommunaute/templates/forum/forum_detail.html
+++ b/lacommunaute/templates/forum/forum_detail.html
@@ -19,7 +19,7 @@
             <div class="s-title-01__row row">
                 <div class="s-title-01__col col-12">
                     <h1>{{ forum.name }}</h1>
-                    {% if user.is_superuser %}
+                    {% if user.is_staff %}
                         <a href="{% url 'forum_extension:edit_forum' forum.slug forum.id %}"><small>Mettre à jour</small></a>
                     {% endif %}
                     {% if forum.short_description %}<h2 class="mt-3">{{ forum.short_description }}</h2>{% endif %}

--- a/lacommunaute/templates/forum/forum_documentation_category.html
+++ b/lacommunaute/templates/forum/forum_documentation_category.html
@@ -3,7 +3,7 @@
     {% include "forum/partials/subcategory_forum_list.html" with forum=forum sub_forums=sub_forums tags_of_descendants=tags_of_descendants active_forum_tag_slug=active_forum_tag_slug only %}
 {% endblock subforum_list %}
 {% block forum_foot_content %}
-    {% if user.is_superuser %}
+    {% if user.is_staff %}
         <section class="s-section" id="add-documentation-to-category-control">
             <div class="s-section__container container">
                 <div class="s-section__row row">

--- a/lacommunaute/templates/partner/detail.html
+++ b/lacommunaute/templates/partner/detail.html
@@ -17,7 +17,7 @@
                         {% endif %}
                         <h1 class="mb-0">{{ partner.name }}</h1>
                     </div>
-                    {% if user.is_superuser %}
+                    {% if user.is_staff %}
                         <a href="{% url 'partner:update' partner.slug partner.pk %}"><small>Mettre à jour</small></a>
                     {% endif %}
                     <h2 class="mt-3">{{ partner.short_description }}</h2>

--- a/lacommunaute/templates/partner/list.html
+++ b/lacommunaute/templates/partner/list.html
@@ -56,7 +56,7 @@
             </div>
         </div>
     </section>
-    {% if user.is_superuser %}
+    {% if user.is_staff %}
         <section class="s-section">
             <div class="s-section__container container">
                 <div class="s-section__row row">


### PR DESCRIPTION
## Description

🎸 permettre aux utilisateurs membre de l'équipe d'accèder aux vues de gestion des `Forum` et des `Partner`

## Type de changement

🚧 technique

### Points d'attention

🦺 suite #913

