### PR TITLE
feat: extension des droits des utilisateurs de l'équipe - edition, deplacement et verrouillage des sujets

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -350,6 +350,7 @@ SUPPORTED_IMAGE_FILE_TYPES = {"image/png": "png", "image/jpeg": "jpeg", "image/j
 SITE_ID = 1
 
 DSP_FORUM_RELATED_ID = 108
+STAFF_GROUP_ID = 48
 
 API_BAN_BASE_URL = "https://api-adresse.data.gouv.fr"
 

--- a/lacommunaute/forum/tests/test_categoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_categoryforum_createview.py
@@ -1,12 +1,20 @@
+import pytest
+from django.conf import settings
 from django.urls import reverse
 from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains
 
 from lacommunaute.forum.models import Forum
-from lacommunaute.users.factories import UserFactory
+from lacommunaute.users.factories import GroupFactory, UserFactory
 
 
 UserForumPermission = get_model("forum_permission", "UserForumPermission")
+GroupForumPermission = get_model("forum_permission", "GroupForumPermission")
+
+
+@pytest.fixture(name="staff_group")
+def fixture_staff_group():
+    return GroupFactory(id=settings.STAFF_GROUP_ID)
 
 
 def test_user_access(client, db):
@@ -33,7 +41,7 @@ def test_form_title_and_context_data(client, db):
     assertContains(response, reverse("forum_extension:documentation"))
 
 
-def test_success_url(client, db):
+def test_success_url(client, db, staff_group):
     client.force_login(UserFactory(is_staff=True))
     url = reverse("forum_extension:create_category")
     response = client.post(url, data={"name": "Test", "description": "Test", "short_description": "Test"})
@@ -41,7 +49,7 @@ def test_success_url(client, db):
     assert response.url == reverse("forum_extension:documentation")
 
 
-def test_create_category_with_perms(client, db):
+def test_create_category_with_perms(client, db, staff_group):
     client.force_login(UserFactory(is_staff=True))
     url = reverse("forum_extension:create_category")
     response = client.post(url, data={"name": "Test", "description": "Test", "short_description": "Test"})
@@ -52,3 +60,4 @@ def test_create_category_with_perms(client, db):
     assert forum.parent is None
 
     assert UserForumPermission.objects.filter(forum=forum).count() == 14
+    assert GroupForumPermission.objects.filter(forum=forum, group=staff_group).count() == 3

--- a/lacommunaute/forum/tests/test_subcategoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_subcategoryforum_createview.py
@@ -1,13 +1,21 @@
+import pytest
+from django.conf import settings
 from django.urls import reverse
 from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains
 
 from lacommunaute.forum.factories import CategoryForumFactory
 from lacommunaute.forum.models import Forum
-from lacommunaute.users.factories import UserFactory
+from lacommunaute.users.factories import GroupFactory, UserFactory
 
 
 UserForumPermission = get_model("forum_permission", "UserForumPermission")
+GroupForumPermission = get_model("forum_permission", "GroupForumPermission")
+
+
+@pytest.fixture(name="staff_group")
+def fixture_staff_group():
+    return GroupFactory(id=settings.STAFF_GROUP_ID)
 
 
 def test_user_access(client, db):
@@ -38,7 +46,7 @@ def test_form_title_and_context_datas(client, db):
     )
 
 
-def test_success_url(client, db):
+def test_success_url(client, db, staff_group):
     client.force_login(UserFactory(is_staff=True))
     category_forum = CategoryForumFactory()
     url = reverse("forum_extension:create_subcategory", kwargs={"pk": category_forum.pk})
@@ -49,7 +57,7 @@ def test_success_url(client, db):
     )
 
 
-def test_create_subcategory_with_perms(client, db):
+def test_create_subcategory_with_perms(client, db, staff_group):
     client.force_login(UserFactory(is_staff=True))
     category_forum = CategoryForumFactory()
     url = reverse("forum_extension:create_subcategory", kwargs={"pk": category_forum.pk})
@@ -61,3 +69,4 @@ def test_create_subcategory_with_perms(client, db):
     assert forum.parent == category_forum
 
     assert UserForumPermission.objects.filter(forum=forum).count() == 14
+    assert GroupForumPermission.objects.filter(forum=forum, group=staff_group).count() == 3

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -17,7 +17,11 @@ from lacommunaute.forum.models import Forum, ForumRating
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.view_mixins import FilteredTopicsListViewMixin
 from lacommunaute.forum_upvote.models import UpVote
-from lacommunaute.utils.perms import add_public_perms_on_forum, forum_visibility_content_tree_from_forums
+from lacommunaute.utils.perms import (
+    add_public_perms_on_forum,
+    add_staff_perms_on_forum,
+    forum_visibility_content_tree_from_forums,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -152,6 +156,7 @@ class BaseCategoryForumCreateView(UserPassesTestMixin, CreateView):
     def form_valid(self, form):
         response = super().form_valid(form)
         add_public_perms_on_forum(form.instance)
+        add_staff_perms_on_forum(form.instance)
         return response
 
 

--- a/lacommunaute/utils/perms.py
+++ b/lacommunaute/utils/perms.py
@@ -1,9 +1,12 @@
+from django.conf import settings
+from django.contrib.auth.models import Group
 from machina.core.db.models import get_model
 from machina.core.loading import get_class
 
 
 ForumPermission = get_model("forum_permission", "ForumPermission")
 UserForumPermission = get_model("forum_permission", "UserForumPermission")
+GroupForumPermission = get_model("forum_permission", "GroupForumPermission")
 ForumVisibilityContentTree = get_class("forum.visibility", "ForumVisibilityContentTree")
 
 
@@ -32,6 +35,16 @@ def add_public_perms_on_forum(forum):
         for permission in ForumPermission.objects.filter(codename__in=perms)
     ]
     UserForumPermission.objects.bulk_create(anonymous_authorized_perms + authentified_authorized_perms)
+
+
+def add_staff_perms_on_forum(forum):
+    permissions = ["can_edit_posts", "can_move_topics", "can_lock_topics"]
+    group = Group.objects.get(id=settings.STAFF_GROUP_ID)
+    authorized_perms = [
+        GroupForumPermission(group=group, permission=permission, has_perm=True, forum=forum)
+        for permission in ForumPermission.objects.filter(codename__in=permissions)
+    ]
+    GroupForumPermission.objects.bulk_create(authorized_perms)
 
 
 def forum_visibility_content_tree_from_forums(request, forums):


### PR DESCRIPTION
## Description

🎸 cf titre

## Type de changement

🚧 technique

🦺 les droits sont ajoutés à un groupe comprennant les utilisateurs `staff`.
🦺 le numéro du groupe est defini en dur dans les settings
