### PR TITLE
fix: desactivation de la collecte automatique des statistiques depuis matomo

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,10 +1,6 @@
 [
     "*/10 * * * * $ROOT/clevercloud/rebuild_index.sh",
     "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
-    "0 6 * * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats",
-    "5 6 * * * $ROOT/clevercloud/run_management_command.sh collect_django_stats",
-    "10 6 1 * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats --period month",
-    "15 6 * * 1 $ROOT/clevercloud/run_management_command.sh collect_matomo_forum_stats",
     "*/15 7-21 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications asap",
     "20 6 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications day",
     "10 6-22 * * * $ROOT/clevercloud/run_management_command.sh add_user_to_list_when_register",


### PR DESCRIPTION
## Description

💥 instabilités quotidiennes matomo

## Type de changement

🚧 technique

### Points d'attention

🦺 lignes retirées de la crontab

```
    "0 6 * * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats",
    "5 6 * * * $ROOT/clevercloud/run_management_command.sh collect_django_stats",
    "10 6 1 * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats --period month",
    "15 6 * * 1 $ROOT/clevercloud/run_management_command.sh collect_matomo_forum_stats",
```