### PR TITLE
feat: modifier la catégorie d'une fiche pratique par les utilisateurs `staff`

### DIFF
--- a/lacommunaute/forum/forms.py
+++ b/lacommunaute/forum/forms.py
@@ -58,3 +58,15 @@ class ForumForm(forms.ModelForm):
     class Meta:
         model = Forum
         fields = ["name", "short_description", "description", "image", "certified", "partner"]
+
+
+class SubCategoryForumUpdateForm(ForumForm):
+    parent = forms.ModelChoiceField(
+        label="Mettre à jour le parent",
+        queryset=Forum.objects.filter(type=Forum.FORUM_CAT, level=0),
+        required=False,
+    )
+
+    class Meta:
+        model = Forum
+        fields = ["name", "short_description", "description", "image", "certified", "partner", "parent"]

--- a/lacommunaute/forum/tests/test_categoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_categoryforum_createview.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains
 
+from lacommunaute.forum.forms import ForumForm, SubCategoryForumUpdateForm
 from lacommunaute.forum.models import Forum
 from lacommunaute.users.factories import GroupFactory, UserFactory
 
@@ -39,6 +40,8 @@ def test_form_title_and_context_data(client, db):
     response = client.get(url)
     assertContains(response, "Créer une nouvelle catégorie documentaire")
     assertContains(response, reverse("forum_extension:documentation"))
+    assert isinstance(response.context["form"], ForumForm)
+    assert not isinstance(response.context["form"], SubCategoryForumUpdateForm)
 
 
 def test_success_url(client, db, staff_group):

--- a/lacommunaute/forum/tests/test_subcategoryforum_createview.py
+++ b/lacommunaute/forum/tests/test_subcategoryforum_createview.py
@@ -5,6 +5,7 @@ from machina.core.db.models import get_model
 from pytest_django.asserts import assertContains
 
 from lacommunaute.forum.factories import CategoryForumFactory
+from lacommunaute.forum.forms import ForumForm, SubCategoryForumUpdateForm
 from lacommunaute.forum.models import Forum
 from lacommunaute.users.factories import GroupFactory, UserFactory
 
@@ -44,6 +45,8 @@ def test_form_title_and_context_datas(client, db):
     assertContains(
         response, reverse("forum_extension:forum", kwargs={"pk": category_forum.pk, "slug": category_forum.slug})
     )
+    assert isinstance(response.context["form"], ForumForm)
+    assert not isinstance(response.context["form"], SubCategoryForumUpdateForm)
 
 
 def test_success_url(client, db, staff_group):

--- a/lacommunaute/forum/tests/tests_forms.py
+++ b/lacommunaute/forum/tests/tests_forms.py
@@ -1,4 +1,5 @@
-from lacommunaute.forum.forms import ForumForm
+from lacommunaute.forum.factories import CategoryForumFactory, ForumFactory
+from lacommunaute.forum.forms import ForumForm, SubCategoryForumUpdateForm
 from lacommunaute.forum.models import Forum
 
 
@@ -14,3 +15,32 @@ def test_form_field():
     assert not form.fields["partner"].required
     assert not form.fields["tags"].required
     assert not form.fields["new_tags"].required
+
+
+def test_subcategoryforumupdateform():
+    form = SubCategoryForumUpdateForm()
+    assert form.Meta.model == Forum
+    assert form.Meta.fields == ["name", "short_description", "description", "image", "certified", "partner", "parent"]
+    assert form.fields["name"].required
+    assert form.fields["short_description"].required
+    assert not form.fields["description"].required
+    assert not form.fields["image"].required
+    assert not form.fields["certified"].required
+    assert not form.fields["partner"].required
+    assert not form.fields["tags"].required
+    assert not form.fields["new_tags"].required
+    assert not form.fields["parent"].required
+
+
+def test_subcategoryforumupdateform_parent(db):
+    form = SubCategoryForumUpdateForm()
+
+    for parent in CategoryForumFactory.create_batch(2):
+        assert parent in form.fields["parent"].queryset
+
+    for not_parent in [
+        ForumFactory(),
+        CategoryForumFactory(with_child=True).get_children().first(),
+        CategoryForumFactory(parent=ForumFactory()),
+    ]:
+        assert not_parent not in form.fields["parent"].queryset

--- a/lacommunaute/forum/views.py
+++ b/lacommunaute/forum/views.py
@@ -12,7 +12,7 @@ from machina.apps.forum.views import ForumView as BaseForumView
 from machina.core.loading import get_class
 from taggit.models import Tag
 
-from lacommunaute.forum.forms import ForumForm
+from lacommunaute.forum.forms import ForumForm, SubCategoryForumUpdateForm
 from lacommunaute.forum.models import Forum, ForumRating
 from lacommunaute.forum_conversation.forms import PostForm
 from lacommunaute.forum_conversation.view_mixins import FilteredTopicsListViewMixin
@@ -125,11 +125,15 @@ class SubCategoryForumListView(BaseForumView, SubCategoryForumListMixin):
 
 class ForumUpdateView(UserPassesTestMixin, UpdateView):
     template_name = "forum/forum_create_or_update.html"
-    form_class = ForumForm
     model = Forum
 
     def test_func(self):
         return self.request.user.is_staff
+
+    def get_form_class(self):
+        if self.object.is_in_documentation_area and self.object.type == Forum.FORUM_POST:
+            return SubCategoryForumUpdateForm
+        return ForumForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/lacommunaute/templates/forum/partials/forum_form.html
+++ b/lacommunaute/templates/forum/partials/forum_form.html
@@ -9,6 +9,9 @@
     {% include "partials/form_field.html" with field=form.name %}
     {% include "partials/form_field.html" with field=form.short_description %}
     {% include "partials/form_field.html" with field=form.description %}
+    {% if form.parent %}
+        {% include "partials/form_field.html" with field=form.parent %}
+    {% endif %}
     {% include "partials/form_field.html" with field=form.image %}
     {% include "partials/form_field.html" with field=form.certified %}
     {% include "partials/form_field.html" with field=form.partner %}


### PR DESCRIPTION
## Description

🎸 La restriction de l'accès à l'admin `django` ne permet plus aux `staff` de déplacer une fiche pratique, d'une catégorie à une autre.
🎸 Autoriser la mise à jour du parent dans le formulaire de mise à jour d'une fiche pratique


## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Le parent est nécéssairement un `Forum` de type `FORUM_CAT` de niveau 0,
🦺 Le parent n'est pas accessible dans les formulaires de création, car il est déduit de la PK contenu dans la route à l'enregistrement,
🦺 Les `Forum` en dehors de l'espace documentaire ne sont pas concernés.


### Captures d'écran (optionnel)

Mise à jour d'une fiche pratique : parent modifiable

![image](https://github.com/user-attachments/assets/74452333-2ecc-4098-83b4-d6f08a2e6020)

Mise à jour d'une catégorie documentaire : parent non accessible

![image](https://github.com/user-attachments/assets/9125f67a-88da-47c8-b2f0-fb9160bc4bb9)

Création d'une nouvelle fiche pratique : parent non accessible

![image](https://github.com/user-attachments/assets/08561563-fd87-47cb-bea0-7d41a5dea584)

