### PR TITLE
fix: encodage de la description des fiches pratiques sur la homepage

### DIFF
--- a/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
+++ b/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
@@ -279,3 +279,23 @@
               </title>
   '''
 # ---
+# name: test_updated_forum_short_description[truncated_encoded_short_description]
+  '''
+  <div class="s-section__col col-12 col-md-8" id="updated_forums">
+                      <p class="h1 text-tertiary">Les fiches pratiques mises à jour</p>
+                      <ul class="list-group list-group-flush list-group-link mb-3 mb-md-4">
+                          
+                              <li class="list-group-item list-group-item-action">
+                                  <div>
+                                      <a class="h4 d-block text-decoration-none text-tertiary stretched-link matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="forum" href="/forum/84-rue-georges-[PK of Forum]/">
+                                          84, rue Georges
+                                      </a>
+                                      <p class="mb-0">C'était partout, dans le monde entier, des centaines ou des milliers de millions de gens s'ignorant les uns les autres, séparés par des murs de haine et de mensonges, et cependant presque exactement …</p>
+                                  </div>
+                              </li>
+                          
+                      </ul>
+                      <a class="btn btn-outline-primary matomo-event" data-matomo-action="view" data-matomo-category="engagement" data-matomo-option="documentation" href="/documentation/">Voir toute la documentation</a>
+                  </div>
+  '''
+# ---

--- a/lacommunaute/pages/tests/test_homepage.py
+++ b/lacommunaute/pages/tests/test_homepage.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from pytest_django.asserts import assertContains, assertNotContains
 
 from lacommunaute.event.factories import EventFactory
-from lacommunaute.forum.factories import ForumFactory
+from lacommunaute.forum.factories import CategoryForumFactory, ForumFactory
 from lacommunaute.forum_conversation.factories import TopicFactory
 from lacommunaute.utils.testing import parse_response_to_soup
 
@@ -73,3 +73,19 @@ def test_numqueries(db, client, django_assert_num_queries):
         + 1  # get upcoming events
     ):
         client.get(reverse("pages:home"))
+
+
+def test_updated_forum_short_description(client, db, snapshot):
+    parent = CategoryForumFactory()
+    forum = ForumFactory(
+        name="84, rue Georges",
+        short_description="C'était partout, dans le monde entier, des centaines ou des milliers de millions de gens "
+        "s'ignorant les uns les autres, séparés par des murs de haine et de mensonges, et cependant presque exactement"
+        " les mêmes, des gens qui n'avaient jamais appris à penser, mais qui emmagasinaient dans leurs cœurs, leurs ve"
+        "ntres et leurs muscles, la force qui, un jour, bouleverserait le monde.",
+        parent=parent,
+    )
+
+    response = client.get(reverse("pages:home"))
+    content = parse_response_to_soup(response, selector="#updated_forums", replace_in_href=[forum])
+    assert str(content) == snapshot(name="truncated_encoded_short_description")

--- a/lacommunaute/templates/pages/home.html
+++ b/lacommunaute/templates/pages/home.html
@@ -132,7 +132,7 @@
                 <div class="s-section__col d-none d-md-inline col-md-4 pe-4">
                     <img src="{% static 'images/home-illu-01.png' %}" class="img-fluid" loading="lazy" alt="">
                 </div>
-                <div class="s-section__col col-12 col-md-8">
+                <div class="s-section__col col-12 col-md-8" id="updated_forums">
                     <p class="h1 text-tertiary">Les fiches pratiques mises à jour</p>
                     <ul class="list-group list-group-flush list-group-link mb-3 mb-md-4">
                         {% for forum in forums_category %}
@@ -145,7 +145,7 @@
                                        class="h4 d-block text-decoration-none text-tertiary stretched-link matomo-event">
                                         {{ forum.name }}
                                     </a>
-                                    <p class="mb-0">{{ forum.short_description|truncatechars_html:200 }}</p>
+                                    <p class="mb-0">{{ forum.short_description|safe|truncatechars_html:200 }}</p>
                                 </div>
                             </li>
                         {% endfor %}


### PR DESCRIPTION
## Description

🎸 Marquer `safe` le champ `short_description` des `Forum` sur la page d'accueil

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).

### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/bb58339b-e4d5-4016-9b5f-0f697ea66678)
