### PR TITLE
feat: faciliter la moderation des `Post` pour les utilisateurs `staff`

### DIFF
--- a/lacommunaute/forum_conversation/shortcuts.py
+++ b/lacommunaute/forum_conversation/shortcuts.py
@@ -38,3 +38,7 @@ def get_posts_of_a_topic_except_first_one(topic: Topic, user: User) -> QuerySet[
 
 def can_certify_post(user):
     return user.is_authenticated and user.is_staff
+
+
+def can_moderate_post(user):
+    return user.is_authenticated and user.is_staff

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -159,15 +159,6 @@
                   </div>
   '''
 # ---
-# name: TestTopicListView.test_queryset_on_filter[CERTIFIED-<lambda>-<lambda>][CERTIFIED-tagged_topics]
-  '''
-  <div class="flex-grow-1" id="topic-list-filter-header">
-                      <span class="h5 m-0">1 question</span>
-                      avec une réponse certifiée
-                      
-                  </div>
-  '''
-# ---
 # name: TestTopicListView.test_queryset_on_filter[NEW-<lambda>-<lambda>][NEW-tagged_topics]
   '''
   <div class="flex-grow-1" id="topic-list-filter-header">

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -218,6 +218,66 @@
                   </div>
   '''
 # ---
+# name: TestTopicUpdateView.test_approved_field_visibility[<lambda>0][approved_field_visibility]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          
+          
+              <input class="form-control" id="id_approved" name="approved" type="hidden" value="True"/>
+          
+      
+      
+      
+      
+  </div>
+  '''
+# ---
+# name: TestTopicUpdateView.test_approved_field_visibility[<lambda>1][approved_field_visibility]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          <div class="form-check mt-2">
+              <input checked="" class="form-check-input" id="id_approved" name="approved" type="checkbox"/>
+              <label class="form-check-label" for="id_approved">Message approuvé</label>
+          </div>
+      
+      
+      
+      
+  </div>
+  '''
+# ---
+# name: TestTopicUpdateView.test_init_approved_value[False][init_approved_value]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          <div class="form-check mt-2">
+              <input class="form-check-input" id="id_approved" name="approved" type="checkbox"/>
+              <label class="form-check-label" for="id_approved">Message approuvé</label>
+          </div>
+      
+      
+      
+      
+  </div>
+  '''
+# ---
+# name: TestTopicUpdateView.test_init_approved_value[True][init_approved_value]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          <div class="form-check mt-2">
+              <input checked="" class="form-check-input" id="id_approved" name="approved" type="checkbox"/>
+              <label class="form-check-label" for="id_approved">Message approuvé</label>
+          </div>
+      
+      
+      
+      
+  </div>
+  '''
+# ---
 # name: test_breadcrumbs_on_topic_view[discussion_area_topic]
   '''
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -1,4 +1,64 @@
 # serializer version: 1
+# name: TestPostUpdateView.test_approved_field_visibility[<lambda>0][approved_field_visibility]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          
+          
+              <input class="form-control" id="id_approved" name="approved" type="hidden" value="True"/>
+          
+      
+      
+      
+      
+  </div>
+  '''
+# ---
+# name: TestPostUpdateView.test_approved_field_visibility[<lambda>1][approved_field_visibility]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          <div class="form-check mt-2">
+              <input checked="" class="form-check-input" id="id_approved" name="approved" type="checkbox"/>
+              <label class="form-check-label" for="id_approved">Message approuvé</label>
+          </div>
+      
+      
+      
+      
+  </div>
+  '''
+# ---
+# name: TestPostUpdateView.test_init_approved_value[False][init_approved_value]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          <div class="form-check mt-2">
+              <input class="form-check-input" id="id_approved" name="approved" type="checkbox"/>
+              <label class="form-check-label" for="id_approved">Message approuvé</label>
+          </div>
+      
+      
+      
+      
+  </div>
+  '''
+# ---
+# name: TestPostUpdateView.test_init_approved_value[True][init_approved_value]
+  '''
+  <div class="form-group" id="div_id_approved">
+      
+          <div class="form-check mt-2">
+              <input checked="" class="form-check-input" id="id_approved" name="approved" type="checkbox"/>
+              <label class="form-check-label" for="id_approved">Message approuvé</label>
+          </div>
+      
+      
+      
+      
+  </div>
+  '''
+# ---
 # name: TestPosterTemplate.test_topic_from_other_public_forum_in_topics_view[topic_from_other_public_forum_in_topics_view]
   '''
   <small class="text-muted poster-infos">

--- a/lacommunaute/forum_conversation/tests/tests_forms.py
+++ b/lacommunaute/forum_conversation/tests/tests_forms.py
@@ -146,7 +146,6 @@ class TestTopicForm:
         assert topic.first_post.username == username
         assert topic.poster is None
         assert topic.first_post.poster is None
-        assert topic.first_post.updates_count == 1
         assert topic.first_post.updated_by == superuser
 
     def test_create_topic_as_authenticated(self, db, client, public_forum):
@@ -178,7 +177,6 @@ class TestTopicForm:
         assert topic.first_post.username is None
         assert topic.poster == user
         assert topic.first_post.poster == user
-        assert topic.first_post.updates_count == 1
         assert topic.first_post.updated_by == user
 
     def test_update_authenticated_topic_as_superuser(self, db, client, public_forum):
@@ -199,7 +197,6 @@ class TestTopicForm:
         assert topic.first_post.username is None
         assert topic.poster == user
         assert topic.first_post.poster == user
-        assert topic.first_post.updates_count == 1
         assert topic.first_post.updated_by == superuser
 
     def test_init_tags_when_creating_topic(self, db, client, public_forum):

--- a/lacommunaute/forum_conversation/tests/tests_shortcuts.py
+++ b/lacommunaute/forum_conversation/tests/tests_shortcuts.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
@@ -70,18 +71,9 @@ class GetPostsofaTopicExceptFirstOneTest(TestCase):
         self.assertTrue(post.has_upvoted)
 
 
-class CanCertifyPostShortcutTest(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.user = UserFactory.create()
-        cls.forum = ForumFactory.create()
-
-    def test_user_is_not_authenticated(self):
-        self.assertFalse(can_certify_post(AnonymousUser()))
-
-    def test_user_is_staff(self):
-        self.user.is_staff = True
-        self.assertTrue(can_certify_post(self.user))
-
-    def test_user_is_not_staff(self):
-        self.assertFalse(can_certify_post(self.user))
+@pytest.mark.parametrize(
+    "user,has_right",
+    [(lambda: AnonymousUser(), False), (lambda: UserFactory(), False), (lambda: UserFactory(is_staff=True), True)],
+)
+def test_can_certify_post(db, user, has_right):
+    assert can_certify_post(user()) == has_right

--- a/lacommunaute/forum_conversation/tests/tests_shortcuts.py
+++ b/lacommunaute/forum_conversation/tests/tests_shortcuts.py
@@ -2,9 +2,12 @@ import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 
-from lacommunaute.forum.factories import ForumFactory
 from lacommunaute.forum_conversation.factories import PostFactory, TopicFactory
-from lacommunaute.forum_conversation.shortcuts import can_certify_post, get_posts_of_a_topic_except_first_one
+from lacommunaute.forum_conversation.shortcuts import (
+    can_certify_post,
+    can_moderate_post,
+    get_posts_of_a_topic_except_first_one,
+)
 from lacommunaute.forum_upvote.factories import UpVoteFactory
 from lacommunaute.users.factories import UserFactory
 
@@ -77,3 +80,11 @@ class GetPostsofaTopicExceptFirstOneTest(TestCase):
 )
 def test_can_certify_post(db, user, has_right):
     assert can_certify_post(user()) == has_right
+
+
+@pytest.mark.parametrize(
+    "user,has_right",
+    [(lambda: AnonymousUser(), False), (lambda: UserFactory(), False), (lambda: UserFactory(is_staff=True), True)],
+)
+def test_can_moderate_post(db, user, has_right):
+    assert can_moderate_post(user()) == has_right

--- a/lacommunaute/forum_moderation/tests/test_moderation_queue_list.py
+++ b/lacommunaute/forum_moderation/tests/test_moderation_queue_list.py
@@ -1,0 +1,19 @@
+import pytest
+from django.urls import reverse
+
+from lacommunaute.forum_conversation.factories import TopicFactory
+from lacommunaute.users.factories import UserFactory
+from lacommunaute.utils.testing import parse_response_to_soup
+
+
+@pytest.mark.parametrize(
+    "topic", [lambda: TopicFactory(with_post=True), lambda: TopicFactory(with_post=True, answered=True)]
+)
+def test_subject_in_list(client, db, topic):
+    client.force_login(UserFactory(is_superuser=True))
+    post = topic().last_post
+    post.approved = False
+    post.save()
+    response = client.get(reverse("forum_moderation:queue"))
+    content = parse_response_to_soup(response, selector="#post-name")
+    assert post.subject in str(content)

--- a/lacommunaute/templates/forum_conversation/partials/post_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/post_form.html
@@ -15,6 +15,7 @@
     {% include "partials/form_field.html" with field=post_form.update_reason %}
 {% endif %}
 {% include "partials/form_field.html" with field=post_form.lock_topic %}
+{% include "partials/form_field.html" with field=post_form.approved %}
 <!-- Sub "forms" tabs -->
 {% if attachment_formset %}
     <ul class="nav nav-tabs nav-tabs--communaute">

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -17,6 +17,7 @@
         {% include "partials/form_field.html" with field=post_form.update_reason %}
     {% endif %}
     {% include "partials/form_field.html" with field=post_form.lock_topic %}
+    {% include "partials/form_field.html" with field=post_form.approved %}
     <!-- Sub "forms" tabs -->
     {% if poll_option_formset or attachment_formset %}
         <ul class="nav nav-tabs nav-tabs--communaute border-bottom-0">

--- a/lacommunaute/templates/forum_moderation/moderation_queue/list.html
+++ b/lacommunaute/templates/forum_moderation/moderation_queue/list.html
@@ -44,7 +44,13 @@
                                 <table class="post-data-table">
                                     <tr>
                                         <td class="post-name">
-                                            <a href="{% url 'forum_moderation:queued_post' post.pk %}" class="post-name-link">{{ post.subject }}</a>
+                                            <a href="{% url 'forum_moderation:queued_post' post.pk %}" class="post-name-link" id="post-name">
+                                                {% if post.subject %}
+                                                    {{ post.subject }}
+                                                {% else %}
+                                                    {{ post.topic.subject }}
+                                                {% endif %}
+                                            </a>
                                             <div>
                                                 <div class="post-created">
                                                     {% if post.poster %}


### PR DESCRIPTION
## Description

🎸 Permettre aux utilisateurs `staff` de moderer un `Post` ou un `Topic` depuis le formulaire de mise à jour.
🎸 Le `Post` et/ou son `Topic` ne sont pas supprimés mais l'état `approved` est mis à `False`. Ils sont visibles dans la queue de moderation

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### Points d'attention

🦺 Décision d'architecture
🦺 Lien avec d'autres PR
🦺 Code sensible


### Captures d'écran (optionnel)

formulaire de mise à jour d'un `Topic` sans droit d'approbation (et mode anonyme)
![image](https://github.com/user-attachments/assets/1a585cc8-e991-4f3c-a3c8-7577f58a873e)

formulaire de mise à jour d'un `Topic` avec droit d'approbation
![image](https://github.com/user-attachments/assets/81312b0a-75b1-4d64-b640-fecbffc86ee6)


formulaire de mise à jour d'un `Post` sans droit d'approbation (et mode anonyme)
![image](https://github.com/user-attachments/assets/ea6b65e3-8d59-46b0-942b-28a7b26cef9b)

formulaire de mise à jour d'un `Post` avec droit d'approbation
![image](https://github.com/user-attachments/assets/f52c4512-0063-4b6f-804c-c73bf56cdc3e)



vue du formulaire de creation d'un `Topic` pour un `staff`

file d'attente de moderation 
![image](https://github.com/user-attachments/assets/148b4ec9-747b-4ba6-a8f7-4c3937256ff0)


