### PR TITLE
chore: rearrangement des tâches planifiées

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,15 +1,15 @@
 [
     "*/10 * * * * $ROOT/clevercloud/rebuild_index.sh",
+    "*/15 7-21 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications asap",
+    "10 6-22 * * * $ROOT/clevercloud/run_management_command.sh add_user_to_list_when_register",
+    "55 8-18 * * 1-5 $ROOT/clevercloud/run_management_command.sh add_missyou_notifications",
     "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
+    "20 6 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications day",
     "0 11 * * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats",
     "5 11 * * * $ROOT/clevercloud/run_management_command.sh collect_django_stats",
-    "10 11 1 * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats --period month",
-    "15 11 * * 1 $ROOT/clevercloud/run_management_command.sh collect_matomo_forum_stats",
-    "*/15 7-21 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications asap",
-    "55 8-18 * * 1-5 $ROOT/clevercloud/run_management_command.sh add_missyou_notifications",
-    "20 6 * * * $ROOT/clevercloud/run_management_command.sh send_messages_notifications day",
-    "10 6-22 * * * $ROOT/clevercloud/run_management_command.sh add_user_to_list_when_register",
-    "0 12  * * 1 $ROOT/clevercloud/run_management_command.sh delete_old_email_sent_tracks",
     "2 12 * * * $ROOT/clevercloud/run_management_command.sh datas_anonymisation",
-    "30 13 * * 1-5 $ROOT/clevercloud/run_management_command.sh send_notifs_on_unanswered_topics"
+    "30 13 * * 1-5 $ROOT/clevercloud/run_management_command.sh send_notifs_on_unanswered_topics",
+    "15 11 * * 1 $ROOT/clevercloud/run_management_command.sh collect_matomo_forum_stats",
+    "0 12  * * 1 $ROOT/clevercloud/run_management_command.sh delete_old_email_sent_tracks",
+    "10 11 1 * * $ROOT/clevercloud/run_management_command.sh collect_matomo_stats --period month"
 ]

--- a/lacommunaute/utils/tests/tests_consistency.py
+++ b/lacommunaute/utils/tests/tests_consistency.py
@@ -1,0 +1,17 @@
+import json
+import pathlib
+
+from crontab import CronTab
+
+
+def test_crontab_order(settings):
+    current_jobs = list(
+        CronTab(
+            tab="\n".join(
+                json.loads(pathlib.Path(settings.ROOT_DIR).joinpath("clevercloud", "cron.json").read_bytes())
+            )
+        )
+    )
+    ordered_jobs = sorted(current_jobs, key=lambda j: (-j.frequency(), j.hour.parts, j.minute.parts))
+
+    assert ordered_jobs == current_jobs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "django-permissions-policy>=4.24",
     "langdetect>=1.0.9",
     "pyjwt>=2.10",
+    "python-crontab>=3.2.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -711,6 +711,7 @@ dependencies = [
     { name = "langdetect" },
     { name = "psycopg" },
     { name = "pyjwt" },
+    { name = "python-crontab" },
     { name = "python-dotenv" },
     { name = "sentry-sdk" },
 ]
@@ -756,6 +757,7 @@ requires-dist = [
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "psycopg", specifier = ">=3.2" },
     { name = "pyjwt", specifier = ">=2.10" },
+    { name = "python-crontab", specifier = ">=3.2.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "sentry-sdk", specifier = ">=2.20" },
 ]
@@ -1071,6 +1073,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
+]
+
+[[package]]
+name = "python-crontab"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f0/25775565c133d4e29eeb607bf9ddba0075f3af36041a1844dd207881047f/python_crontab-3.2.0.tar.gz", hash = "sha256:40067d1dd39ade3460b2ad8557c7651514cd3851deffff61c5c60e1227c5c36b", size = 57001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/91/832fb3b3a1f62bd2ab4924f6be0c7736c9bc4f84d3b153b74efcf6d4e4a1/python_crontab-3.2.0-py3-none-any.whl", hash = "sha256:82cb9b6a312d41ff66fd3caf3eed7115c28c195bfb50711bc2b4b9592feb9fe5", size = 27351 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

🎸 ré-arrangement des tâches planifiées par fréquence > heure > minute
🧑‍🍳 la fréquence est le nombre d'executions attendues dans une année
🛸 ajout de la lib `python-crontab`


## Type de changement

🚧 technique

### Points d'attention

🦺 ajout d'un test sur l'arrangement des tâches dans `cron.json` 
🦺 thks to @rsebille 

