### PR TITLE
fix: ajout de l'autorisation `can_download_file`

### DIFF
--- a/lacommunaute/forum_permission/migrations/0002_perms_update.py
+++ b/lacommunaute/forum_permission/migrations/0002_perms_update.py
@@ -30,6 +30,7 @@ def setup_global_permissions(apps, schema_editor):
         "can_edit_own_posts",
         "can_delete_own_posts",
         "can_post_without_approval",
+        "can_download_file",
     ]
 
     anonymous_perms = [


### PR DESCRIPTION
## Description

🎸 fix #933 , ajout permission manquante `can_download_file`

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
