### PR TITLE
feat: desapprobation de contenus

### DIFF
--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -1,4 +1,49 @@
 # serializer version: 1
+# name: TestPostUpdateView.test_button_visibility_for_user[False-<lambda>0][form-actions-buttons]
+  '''
+  <div class="form-actions form-row">
+                              <div class="form-group col-auto">
+                                  <input class="btn btn-primary" type="submit" value="Publier"/>
+                              </div>
+                              
+                              
+                                  <div class="form-group col-auto">
+                                      <input class="btn btn-outline-warning" name="unapprove" type="submit" value="Unapprove"/>
+                                  </div>
+                              
+                          </div>
+  '''
+# ---
+# name: TestPostUpdateView.test_button_visibility_for_user[True-<lambda>0][form-actions-buttons]
+  '''
+  <div class="form-actions form-row">
+                              <div class="form-group col-auto">
+                                  <input class="btn btn-primary" type="submit" value="Publier"/>
+                              </div>
+                              
+                              
+                                  <div class="form-group col-auto">
+                                      <a class="btn btn-outline-danger" href="/forum/[forum-slug-pk]/topic/[topic-slug-pk]/[PK of Post]/post/delete/" role="button" value="Supprimer">Supprimer</a>
+                                  </div>
+                              
+                          </div>
+  '''
+# ---
+# name: TestPostUpdateView.test_button_visibility_for_user[True-<lambda>1][form-actions-buttons]
+  '''
+  <div class="form-actions form-row">
+                              <div class="form-group col-auto">
+                                  <input class="btn btn-primary" type="submit" value="Publier"/>
+                              </div>
+                              
+                              
+                                  <div class="form-group col-auto">
+                                      <a class="btn btn-outline-danger" href="/forum/[forum-slug-pk]/topic/[topic-slug-pk]/[PK of Post]/post/delete/" role="button" value="Supprimer">Supprimer</a>
+                                  </div>
+                              
+                          </div>
+  '''
+# ---
 # name: TestPosterTemplate.test_topic_from_other_public_forum_in_topics_view[topic_from_other_public_forum_in_topics_view]
   '''
   <small class="text-muted poster-infos">

--- a/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
+++ b/lacommunaute/forum_conversation/tests/__snapshots__/tests_views.ambr
@@ -149,6 +149,57 @@
                   </div>
   '''
 # ---
+# name: TestTopicUpdateView.test_button_visibility_for_user[False-<lambda>0][form-actions-buttons]
+  '''
+  <div class="form-actions form-row">
+          <div class="form-group col-auto">
+              <input class="btn btn-primary matomo-event" data-matomo-action="contribute" data-matomo-category="engagement" data-matomo-option="submit_topic" type="submit" value="Publier"/>
+          </div>
+          
+              
+              
+                  <div class="form-group col-auto">
+                      <input class="btn btn-outline-warning" name="unapprove" type="submit" value="Unapprove"/>
+                  </div>
+              
+          
+      </div>
+  '''
+# ---
+# name: TestTopicUpdateView.test_button_visibility_for_user[True-<lambda>0][form-actions-buttons]
+  '''
+  <div class="form-actions form-row">
+          <div class="form-group col-auto">
+              <input class="btn btn-primary matomo-event" data-matomo-action="contribute" data-matomo-category="engagement" data-matomo-option="submit_topic" type="submit" value="Publier"/>
+          </div>
+          
+              
+              
+                  <div class="form-group col-auto">
+                      <a aria-label="Supprimer" class="btn btn-outline-danger" href="/forum/[forum-slug-pk]/topic/[topic-slug-pk]/[PK of Post]/post/delete/" role="button">Supprimer</a>
+                  </div>
+              
+          
+      </div>
+  '''
+# ---
+# name: TestTopicUpdateView.test_button_visibility_for_user[True-<lambda>1][form-actions-buttons]
+  '''
+  <div class="form-actions form-row">
+          <div class="form-group col-auto">
+              <input class="btn btn-primary matomo-event" data-matomo-action="contribute" data-matomo-category="engagement" data-matomo-option="submit_topic" type="submit" value="Publier"/>
+          </div>
+          
+              
+              
+                  <div class="form-group col-auto">
+                      <a aria-label="Supprimer" class="btn btn-outline-danger" href="/forum/[forum-slug-pk]/topic/[topic-slug-pk]/[PK of Post]/post/delete/" role="button">Supprimer</a>
+                  </div>
+              
+          
+      </div>
+  '''
+# ---
 # name: test_breadcrumbs_on_topic_view[discussion_area_topic]
   '''
   <nav aria-label="Fil d'ariane" class="c-breadcrumb">

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -708,6 +708,73 @@ class PostUpdateViewTest(TestCase):
         self.assertEqual(post.username, "john@doe.com")
 
 
+class TestPostUpdateView:
+    @pytest.mark.parametrize("user", [lambda: UserFactory(is_in_staff_group=True), lambda: UserFactory()])
+    @pytest.mark.parametrize("is_poster", [True, False])
+    def test_button_visibility_for_user(self, client, db, user, is_poster, snapshot):
+        user = user()
+        client.force_login(user)
+
+        topic = TopicFactory(with_post=True)
+        post = PostFactory(topic=topic, poster=user) if is_poster else PostFactory(topic=topic)
+
+        response = client.get(
+            reverse(
+                "forum_conversation:post_update",
+                kwargs={
+                    "forum_slug": topic.forum.slug,
+                    "forum_pk": topic.forum.pk,
+                    "topic_slug": topic.slug,
+                    "topic_pk": topic.pk,
+                    "pk": post.pk,
+                },
+            )
+        )
+
+        assert response.status_code == (200 if user.is_staff or is_poster else 403)
+
+        if response.status_code == 200:
+            content = parse_response_to_soup(
+                response,
+                selector="div.form-actions",
+                replace_in_href=[
+                    (f"{topic.forum.slug}-{topic.forum.pk}", "[forum-slug-pk]"),
+                    (f"{topic.slug}-{topic.pk}", "[topic-slug-pk]"),
+                    post,
+                ],
+            )
+            assert str(content) == snapshot(name="form-actions-buttons")
+
+    @pytest.mark.parametrize("user", [lambda: UserFactory(is_in_staff_group=True), lambda: UserFactory(), None])
+    @pytest.mark.parametrize("name", [None, "dummy", "unapprove"])
+    def test_post_update(self, db, client, user, name):
+        topic = TopicFactory(with_post=True)
+        data = {"content": "content", name: True} if name else {"content": "content"}
+        if user:
+            user = user()
+            client.force_login(user)
+
+        post = PostFactory(topic=topic, poster=user) if user else AnonymousPostFactory(topic=topic)
+
+        response = client.post(
+            reverse(
+                "forum_conversation:post_update",
+                kwargs={
+                    "forum_slug": topic.forum.slug,
+                    "forum_pk": topic.forum.pk,
+                    "topic_slug": topic.slug,
+                    "topic_pk": topic.pk,
+                    "pk": post.pk,
+                },
+            ),
+            data,
+            follow=True,
+        )
+        assert response.status_code == 200
+        post.refresh_from_db()
+        assert post.approved is not (user and user.is_staff and name == "unapprove")
+
+
 class PostDeleteViewTest(TestCase):
     def test_redirection(self):
         topic = TopicFactory(with_post=True)

--- a/lacommunaute/forum_conversation/tests/tests_views.py
+++ b/lacommunaute/forum_conversation/tests/tests_views.py
@@ -449,6 +449,69 @@ class TopicUpdateViewTest(TestCase):
         self.assertEqual(topic.first_post.content.raw, initial_raw_content)
 
 
+class TestTopicUpdateView:
+    @pytest.mark.parametrize("user", [lambda: UserFactory(is_in_staff_group=True), lambda: UserFactory()])
+    @pytest.mark.parametrize("is_poster", [True, False])
+    def test_button_visibility_for_user(self, db, client, user, is_poster, snapshot):
+        user = user()
+        topic = TopicFactory(with_post=True, poster=user) if is_poster else TopicFactory(with_post=True)
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse(
+                "forum_conversation:topic_update",
+                kwargs={
+                    "forum_slug": topic.forum.slug,
+                    "forum_pk": topic.forum.pk,
+                    "slug": topic.slug,
+                    "pk": topic.pk,
+                },
+            )
+        )
+
+        assert response.status_code == (200 if user.is_staff or is_poster else 403)
+
+        if response.status_code == 200:
+            content = parse_response_to_soup(
+                response,
+                selector="div.form-actions",
+                replace_in_href=[
+                    (f"{topic.forum.slug}-{topic.forum.pk}", "[forum-slug-pk]"),
+                    (f"{topic.slug}-{topic.pk}", "[topic-slug-pk]"),
+                    topic.first_post,
+                ],
+            )
+            assert str(content) == snapshot(name="form-actions-buttons")
+
+    @pytest.mark.parametrize("user", [lambda: UserFactory(is_in_staff_group=True), lambda: UserFactory(), None])
+    @pytest.mark.parametrize("name", [None, "dummy", "unapprove"])
+    def test_topic_update(self, db, client, user, name):
+        data = {"content": "content", name: True} if name else {"content": "content"}
+        if user:
+            user = user()
+            client.force_login(user)
+
+        topic = TopicFactory(with_post=True, poster=user) if user else AnonymousTopicFactory(with_post=True)
+
+        response = client.post(
+            reverse(
+                "forum_conversation:topic_update",
+                kwargs={
+                    "forum_slug": topic.forum.slug,
+                    "forum_pk": topic.forum.pk,
+                    "slug": topic.slug,
+                    "pk": topic.pk,
+                },
+            ),
+            data,
+            follow=True,
+        )
+        assert response.status_code == 200
+        topic.refresh_from_db()
+        assert topic.first_post.approved is not (user and user.is_staff and name == "unapprove")
+
+
 class PostCreateViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -55,6 +55,13 @@ class TopicCreateView(FormValidMixin, views.TopicCreateView):
 class TopicUpdateView(FormValidMixin, views.TopicUpdateView):
     post_form_class = TopicForm
 
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if request.POST.get("unapprove") and self.request.user.is_staff:
+            self.object.first_post.approved = False
+            self.object.first_post.save()
+        return super().post(request, *args, **kwargs)
+
 
 class PostCreateView(views.PostCreateView):
     def perform_permissions_check(self, user, obj, perms):

--- a/lacommunaute/forum_conversation/views.py
+++ b/lacommunaute/forum_conversation/views.py
@@ -69,7 +69,12 @@ class PostCreateView(views.PostCreateView):
 
 
 class PostUpdateView(FormValidMixin, views.PostUpdateView):
-    pass
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if request.POST.get("unapprove") and self.request.user.is_staff:
+            self.object.approved = False
+            self.object.save()
+        return super().post(request, *args, **kwargs)
 
 
 class PostDeleteView(views.PostDeleteView):

--- a/lacommunaute/templates/forum_conversation/partials/topic_form.html
+++ b/lacommunaute/templates/forum_conversation/partials/topic_form.html
@@ -97,6 +97,10 @@
                 <div class="form-group col-auto">
                     <a href="{% url 'forum_conversation:post_delete' forum.slug forum.pk topic.slug topic.pk post.pk %}" aria-label="{% trans "Delete" %}" role="button" class="btn btn-outline-danger">{% trans "Delete" %}</a>
                 </div>
+            {% elif user.is_staff %}
+                <div class="form-group col-auto">
+                    <input type="submit" class="btn btn-outline-warning" name="unapprove" value="{% trans "Unapprove" %}" />
+                </div>
             {% endif %}
         {% endif %}
     </div>

--- a/lacommunaute/templates/forum_conversation/post_update.html
+++ b/lacommunaute/templates/forum_conversation/post_update.html
@@ -30,6 +30,10 @@
                                 <div class="form-group col-auto">
                                     <a href="{% url 'forum_conversation:post_delete' forum.slug forum.pk topic.slug topic.pk post.pk %}" role="button" class="btn btn-outline-danger" value="{% trans "Delete" %}">{% trans "Delete" %}</a>
                                 </div>
+                            {% elif user.is_staff %}
+                                <div class="form-group col-auto">
+                                    <input type="submit" class="btn btn-outline-warning" name="unapprove" value="{% trans "Unapprove" %}" />
+                                </div>
                             {% endif %}
                         </div>
                     </form>


### PR DESCRIPTION
## Description

🎸 Permettre aux utilisateurs `staff` de desapprouver des `Post` et des `Topic` enregistré par d'autres utilisateurs

reprise du sujet, suite à l'echec de la #928

## Type de changement

🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).

### point d'attention

🦺 utilisation d'une balise `name="unapprove"` dans le tag `<input type="submit"` pour distinguer la mise à jour de la désapprobation
🦺 les tentatives de desapprobation pour des utilisateurs non `staff` ne modifient pas la valeur de `approved`
 silencieusement

### Captures d'écran (optionnel)

![image](https://github.com/user-attachments/assets/b5d363bd-67e1-4db7-8db4-30288d0b6b23)
