### PR TITLE
Pages statiques : utilisation du haut de page par défaut

### DIFF
--- a/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
+++ b/lacommunaute/pages/tests/__snapshots__/test_homepage.ambr
@@ -141,7 +141,7 @@
               <div class="s-header__row row">
                   <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pe-0">
                       <a class="s-header__logo-ministere" href="/">
-                          <img alt="Rébublique Française" src="/static/vendor/theme-inclusion/images/logo-republique-francaise.svg"/>
+                          <img alt="République Française" src="/static/vendor/theme-inclusion/images/logo-republique-francaise.svg"/>
                       </a>
                   </div>
                   <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">

--- a/lacommunaute/templates/flatpages/default.html
+++ b/lacommunaute/templates/flatpages/default.html
@@ -1,7 +1,9 @@
 {% extends "layouts/base.html" %}
 {% block title %}{{ flatpage.title }}{{ block.super }}{% endblock %}
 {% block body_class %}{{ block.super }}{% endblock %}
-{% block header %}{% endblock %}
+{% block header %}
+    {% include "partials/header.html" %}
+{% endblock %}
 {% block content %}{{ flatpage.content }}{% endblock %}
 {% block footer %}
     {% include "partials/footer.html" %}

--- a/lacommunaute/templates/middleware/parking.html
+++ b/lacommunaute/templates/middleware/parking.html
@@ -19,7 +19,7 @@
                     <div class="s-header__row row">
                         <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pe-0">
                             <a href="{% url 'pages:home' %}" class="s-header__logo-ministere">
-                                <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française">
+                                <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="République Française">
                             </a>
                         </div>
                         <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">

--- a/lacommunaute/templates/partials/header.html
+++ b/lacommunaute/templates/partials/header.html
@@ -16,7 +16,7 @@
             <div class="s-header__row row">
                 <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center pe-0">
                     <a href="{% url 'pages:home' %}" class="s-header__logo-ministere">
-                        <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="Rébublique Française">
+                        <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" alt="République Française">
                     </a>
                 </div>
                 <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">


### PR DESCRIPTION
## Description

Actuellement, le haut de page est géré dans l'admin de Django comme n'importe quel contenu modifiable.
Cela nous empêche de suivre les changements réalisés car le contenu n'est pas suivi par Git.
Le contenu étant dupliqué d'une page à l'autre, il est plus difficile à maintenir.

J'ai aussi corrigé une faute d'orthographe : République française (et non Rébublique).

### Captures d'écran
Avant
![image](https://github.com/user-attachments/assets/801d2669-6899-4936-a034-7678ffe96e44)


Après
![image](https://github.com/user-attachments/assets/9a8577b8-be09-4b18-9437-fb04988388f2)
