### PR TITLE
Amélioration de la performance des requêtes

### DIFF
--- a/lacommunaute/forum_upvote/tests/test_upvotelistview.py
+++ b/lacommunaute/forum_upvote/tests/test_upvotelistview.py
@@ -77,6 +77,5 @@ def test_numqueries(client, db, django_assert_num_queries):
     ForumFactory.create_batch(20, upvoted_by=[user])
     PostFactory.create_batch(20, topic=TopicFactory(), upvoted_by=[user])
 
-    # vincentporte : to be optimized
-    with django_assert_num_queries(38):
+    with django_assert_num_queries(25):
         client.get(url)

--- a/lacommunaute/forum_upvote/views.py
+++ b/lacommunaute/forum_upvote/views.py
@@ -15,7 +15,9 @@ from lacommunaute.forum_upvote.models import UpVote
 
 logger = logging.getLogger(__name__)
 
-PermissionRequiredMixin = get_class("forum_permission.viewmixins", "PermissionRequiredMixin")
+PermissionRequiredMixin = get_class(
+    "forum_permission.viewmixins", "PermissionRequiredMixin"
+)
 TrackingHandler = get_class("forum_tracking.handler", "TrackingHandler")
 
 track_handler = TrackingHandler()
@@ -55,11 +57,15 @@ class BaseUpvoteMixin:
         self.handle_extra_logic(request)
 
         return render(
-            request, "partials/upvotes.html", context={"obj": self.object, "kind": self.object._meta.model_name}
+            request,
+            "partials/upvotes.html",
+            context={"obj": self.object, "kind": self.object._meta.model_name},
         )
 
     def handle_extra_logic(self, request):
-        raise NotImplementedError("handle_extra_logic method must be implemented in the subclass")
+        raise NotImplementedError(
+            "handle_extra_logic method must be implemented in the subclass"
+        )
 
 
 class PostUpvoteView(BaseUpvoteMixin, PermissionRequiredMixin, View):
@@ -102,8 +108,13 @@ class UpVoteListView(LoginRequiredMixin, ListView):
     def get_queryset(self):
         qs = (
             UpVote.objects.filter(voter=self.request.user)
-            .select_related("content_type")
-            .prefetch_related("content_object")
+            .select_related("content_type", "voter")
+            .prefetch_related(
+                "content_object",
+                "content_object__topic",
+                "content_object__topic__forum",
+                "content_object__poster",
+            )
             .order_by("-created_at")
         )
         return qs


### PR DESCRIPTION
## Description

Certaines requêtes généraient des sous-requêtes cachées (N+1). Curieusement, la CI passait mais pas les tests en local qui affichaient bien les N+1. Changer le setting `FORUM_TOPICS_NUMBER_PER_PAGE` augmentait le nombre de requêtes.
Je corrige dans cette PR les requêtes en question.

## Type de changement

🪲 Correction de bug (changement non cassant qui corrige un problème).
🎢 Nouvelle fonctionnalité (changement non cassant qui ajoute une fonctionnalité).
🥁 Changement de rupture (modification ou caractéristique qui empêcherait une fonctionnalité existante de fonctionner comme prévu) nécéssitant une mise à jour de la documentation
🎨 changement d'UI
🚧 technique

### Points d'attention

🦺 Décision d'architecture
🦺 Lien avec d'autres PR
🦺 Code sensible


### Captures d'écran (optionnel)

Utile pour les changements liés à l'UI.
