### PR TITLE
Documenter la connexion aux recettes jetables

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,18 @@ Ajouter les secrets suivants dans le repo git
 - CLEVER_REVIEW_APPS_CONFIGURATION_ADDON
 - CLEVER_REVIEW_APPS_ORG
 - CLEVER_REVIEW_APPS_S3_ADDON
+
+## Recettes jetables
+
+Les recettes jetables sont créées lorsque l'étiquette « recette-jetable » est ajoutée.
+Lorsque l'étiquette est supprimée, la recette jetable l'est aussi.
+Voir les GitHub actions `.github/workflows/review_app_creation.yml` et `.github/workflow/review_app_removal.yml`.
+
+### Comptes de test
+
+Des données fictives sont créées pour les recettes jetables. Voir la commande de gestion `forum/management/commands/populate.py`.
+- Compte superadministrateur : `admin` et `supercalifragilisticexpialidocious`.
+- Compte équipe : `staff` et `supercalifragilisticexpialidocious`.
+
+Vous pouvez utiliser l'interface d'administration de Django avec le compte super-administrateur
+pour changer les adresses email.

--- a/lacommunaute/forum/management/commands/populate.py
+++ b/lacommunaute/forum/management/commands/populate.py
@@ -18,11 +18,13 @@ class Command(BaseCommand):
 
         UserFactory(
             email="super@inclusion.gouv.fr",
+            username="admin",
             is_superuser=True,
             is_staff=True,
         )
         sys.stdout.write("superuser created\n")
-        UserFactory(email="staff@inclusion.gouv.fr", is_in_staff_group=True)
+        UserFactory(email="staff@inclusion.gouv.fr", username="staff", is_in_staff_group=True)
+
         sys.stdout.write("staff created\n")
 
         partners = PartnerFactory.create_batch(5, with_logo=True)


### PR DESCRIPTION
## Description

Il était difficile de trouver comment se connecter à l'interface d'administration
de Django dans les recettes jetables.

## Type de changement

- Ajout de documentation.
- Ajout d'un nom d'utilisateur à la fonction qui les crée. 
