### PR TITLE
Ajouter un index sur les colonnes forum tree_id, lft

### DIFF
--- a/lacommunaute/forum/migrations/0022_forum_forum_forum_tree_id_lft_idx.py
+++ b/lacommunaute/forum/migrations/0022_forum_forum_forum_tree_id_lft_idx.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("forum", "0021_remove_forum_kind"),
+        ("forum_conversation", "0009_run_management"),
+        ("partner", "0002_alter_partner_options"),
+        ("taggit", "0006_rename_taggeditem_content_type_object_id_taggit_tagg_content_8fc721_idx"),
+    ]
+
+    operations = [
+        migrations.RunSQL("DROP INDEX IF EXISTS forum_forum_tree_id_lft_idx;", elidable=True),
+        migrations.AddIndex(
+            model_name="forum",
+            index=models.Index(fields=["tree_id", "lft"], name="forum_forum_tree_id_lft_idx"),
+        ),
+    ]

--- a/lacommunaute/forum/models.py
+++ b/lacommunaute/forum/models.py
@@ -45,6 +45,14 @@ class Forum(AbstractForum):
             },
         )
 
+    class Meta(AbstractForum.Meta):
+        indexes = [
+            # MPTT isn’t supported anymore, and the index is only created for Django<5.
+            # https://github.com/django-mptt/django-mptt/commit/c169d90cf868ad5f0665d850706aaf5d3ef3923f
+            # https://github.com/django-mptt/django-mptt/pull/845
+            models.Index(fields=["tree_id", "lft"], name="forum_forum_tree_id_lft_idx"),
+        ]
+
     def get_unanswered_topics(self):
         return Topic.objects.unanswered().filter(forum__in=self.get_descendants(include_self=True))
 


### PR DESCRIPTION
## Description

L’index devrait être créé automatiquement par Django MPTT, mais il n’est pas créé pour Django 5.
https://github.com/django-mptt/django-mptt/commit/c169d90cf868ad5f0665d850706aaf5d3ef3923f

Le problème devrait être résolu avec https://github.com/django-mptt/django-mptt/pull/845.

## Type de changement

🚧 technique (perfs, suite à l’incident clever cloud https://www.clevercloudstatus.com/incidents/1011)
